### PR TITLE
group dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Context

Currently dependabot raises one PR per dependancy, these are laborious to merge because for each PR we need to:
* rebase it against main (due to poetry.lock merge conflicts)
* approve
* wait for CI to pass
* merge

## Changes proposed in this pull request

Dependabot has recently added a new feature to group PRs https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/. I have modified the config so that:
1. all minor and patch updates are grouped together into 1 PR
2. all major updates are still standalone PRs

## Guidance to review

- [x] do we want this ?
- [x] merge it and try it IRL

## Link to JIRA ticket

n/a

## Things to check

~- [ ] I have added any new ENV vars in all deployed environments~
