### PR TITLE
lower elasticsearch memory requirements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - 9300:9300
     environment:
       # node.name: elasticsearch
-      # ES_JAVA_OPTS: -Xms512m -Xmx2048m
+      ES_JAVA_OPTS: -Xms512m -Xmx2048m
       # ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-}
       discovery.type: single-node
       xpack.security.enabled: "false"


### PR DESCRIPTION
## Context

By default ElasticSearch requires 8gb of RAM, this is not necessary or helpful for local dev and or testing.

## Changes proposed in this pull request

An existing 1gb mem setting as been uncommented.

## Guidance to review

- [ ] does this run with docker/colima running with 4gb of allocated mem

## Link to JIRA ticket

n/a

## Things to check

~- [ ] I have added any new ENV vars in all deployed environments~
