### PR TITLE
Changed slack integration to use webhook url instead of bot token

### DIFF
--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -60,7 +60,6 @@ jobs:
       uses: slackapi/slack-github-action@v1.24.0
       if: ${{ failure() && github.event_name == 'schedule' }}
       with:
-        channel-id: 'C05D67P6M34'
         payload: |
           {
             "text": "Scheduled AI tests failed",
@@ -91,7 +90,7 @@ jobs:
             ]
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: Notify Slack pass
@@ -99,7 +98,6 @@ jobs:
       uses: slackapi/slack-github-action@v1.24.0
       if: ${{ success() && github.event_name == 'schedule' }}
       with:
-        channel-id: 'C05D67P6M34'
         payload: |
           {
             "text": "Scheduled AI tests passed",
@@ -114,7 +112,7 @@ jobs:
             ]
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: Dump logs

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -107,7 +107,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.24.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C05D67P6M34'
           payload: |
             {
               "text": "Failed to deploy to ${{ inputs.environment }}",
@@ -122,7 +121,7 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: notify slack pass
@@ -130,7 +129,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.24.0
         if: ${{ success() }}
         with:
-          channel-id: 'C05D67P6M34'
           payload: |
             {
               "text": "Deployment to ${{ inputs.environment }} succeeded :airplane:",
@@ -145,7 +143,7 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   stop-runner:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -81,7 +81,6 @@ jobs:
       uses: slackapi/slack-github-action@v1.24.0
       if: ${{ failure() && github.event_name == 'schedule' }}
       with:
-        channel-id: 'C05D67P6M34'
         payload: |
           {
             "text": "Scheduled Integration Tests Failed",
@@ -112,7 +111,7 @@ jobs:
             ]
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: notify slack pass
@@ -120,7 +119,6 @@ jobs:
       uses: slackapi/slack-github-action@v1.24.0
       if: ${{ success() && github.event_name == 'schedule' }}
       with:
-        channel-id: 'C05D67P6M34'
         payload: |
           {
             "text": "Scheduled Integration Tests Passed",
@@ -135,7 +133,7 @@ jobs:
             ]
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: Dump logs


### PR DESCRIPTION
## Context

We couldn't get the slack bot token back, so I've changed the slack integration to use the webhook url instead from a slack app to make it recoverable.

## Changes proposed in this pull request

- Remove channel-id
- Change slack bot token to webhook url

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
