### PR TITLE
chore/increase storage to 30 gb for core and worker

### DIFF
--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -139,6 +139,7 @@ module "core_api" {
   ip_whitelist                 = var.external_ips
   environment_variables        = local.core_api_environment_variables
   secrets                      = local.reconstructed_core_secrets
+  ephemeral_storage            = 30
 }
 
 
@@ -165,6 +166,7 @@ module "worker" {
   environment_variables        = local.worker_environment_variables
   secrets                      = local.reconstructed_worker_secrets
   http_healthcheck             = false
+  ephemeral_storage            = 30
 }
 
 


### PR DESCRIPTION
## Context

As an Engineer I want to increase the storage for the core-api and worker 

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
