### PR TITLE
Improve focus behaviour of chat messages and feedback

### DIFF
--- a/django_app/frontend/src/js/chats/feedback.js
+++ b/django_app/frontend/src/js/chats/feedback.js
@@ -15,7 +15,7 @@ class FeedbackButtons extends HTMLElement {
     `;
 
     this.innerHTML = `
-        <div class="feedback__container feedback__container--1">
+        <div class="feedback__container feedback__container--1" tabindex="-1">
             <h3 class="feedback__heading">Rate this response:</h3>
             <div class="feedback__star-container">
                 <span class="feedback__star-help-text" aria-hidden="true">Not helpful</span>
@@ -42,7 +42,7 @@ class FeedbackButtons extends HTMLElement {
                 <span class="feedback__star-help-text" aria-hidden="true">Very helpful</span>
             </div>
         </div>
-        <div class="feedback__container feedback__container--2" hidden>
+        <div class="feedback__container feedback__container--2" hidden tabindex="-1">
             <div class="feedback__response-container">
                 <img src="/static/icons/thumbs-up.svg" alt=""/>
                 <span class="feedback__negative">Sorry this didn't meet your expectations</span>
@@ -50,7 +50,7 @@ class FeedbackButtons extends HTMLElement {
             </div>
             <button class="feedback__improve-response-btn" type="button">Help improve the response</button>
         </div>
-        <div class="feedback__container feedback__container--3" hidden>
+        <div class="feedback__container feedback__container--3" hidden tabindex="-1">
             <fieldset class="feedback__chips-container feedback__negative">
                 <legend class="feedback__chips-legend">How would you describe the response?</legend>
                 <div class="feedback__chips-inner-container">
@@ -77,7 +77,7 @@ class FeedbackButtons extends HTMLElement {
             <textarea class="feedback__text-input" id="text-${messageId}" rows="1"></textarea>
             <button class="feedback__submit-btn" type="button">Submit</button>
         </div>
-        <div class="feedback__container feedback__container--4" hidden>
+        <div class="feedback__container feedback__container--4" hidden tabindex="-1">
            <span>Thanks for helping improve this response</span>
            <button class="feedback__rate-again-btn" type="button">Rate response again</button> 
         </div>
@@ -105,11 +105,13 @@ class FeedbackButtons extends HTMLElement {
      * @param {number} panelIndex - zero based
      */
     const showPanel = (panelIndex) => {
+      /** @type {NodeListOf<HTMLElement>} */
       let panels = this.querySelectorAll(".feedback__container");
       panels.forEach((panel) => {
         panel.setAttribute("hidden", "");
       });
       panels[panelIndex].removeAttribute("hidden");
+      panels[panelIndex].focus();
       if (collectedData.rating >= 3) {
         panels[panelIndex].classList.remove("feedback__container--negative");
         panels[panelIndex].classList.add("feedback__container--positive");

--- a/django_app/frontend/src/js/chats/streaming.js
+++ b/django_app/frontend/src/js/chats/streaming.js
@@ -60,7 +60,7 @@ class ChatMessage extends HTMLElement {
     this.innerHTML = `
             <div class="iai-chat-bubble iai-chat-bubble--${
               this.dataset.role === "user" ? "right" : "left"
-            } js-chat-message govuk-body {{ classes }}" data-role="{{ role }}" tabindex="-1">
+            } govuk-body {{ classes }}" data-role="{{ role }}" tabindex="-1">
                 <div class="iai-chat-bubble__header">
                     <div class="iai-chat-bubble__role">${
                       this.dataset.role === "ai" ? "Redbox" : "You"
@@ -242,7 +242,6 @@ class ChatController extends HTMLElement {
         document.createElement("chat-message")
       );
       aiMessage.setAttribute("data-role", "ai");
-      aiMessage.setAttribute("tabindex", "-1");
       messageContainer?.insertBefore(aiMessage, insertPosition);
       aiMessage.stream(
         userText,
@@ -251,7 +250,9 @@ class ChatController extends HTMLElement {
         this.dataset.streamUrl || "",
         this
       );
-      aiMessage.focus();
+      /** @type {HTMLElement | null} */ (
+        aiMessage.querySelector(".iai-chat-bubble")
+      )?.focus();
 
       // reset UI
       if (feedbackButtons) {

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -32,7 +32,7 @@
         {% set role_text = "You" %}
     {% endif %}
 
-    <div class="iai-chat-bubble iai-chat-bubble--{% if role == 'user' %}right{% else %}left{% endif %} js-chat-message govuk-body {{ classes }}" data-role="{{ role }}" tabindex="-1">
+    <div class="iai-chat-bubble iai-chat-bubble--{% if role == 'user' %}right{% else %}left{% endif %} govuk-body {{ classes }}" data-role="{{ role }}" tabindex="-1">
       <div class="iai-chat-bubble__header">
         <div class="iai-chat-bubble__role">{% if role == "ai" %}Redbox{% else %}You{% endif %}</div>
         {% if route and show_route %}


### PR DESCRIPTION
## Context

A couple of improvements primarily for keyboard-only and screen-reader users


## Changes proposed in this pull request

* The feedback functionality is split into 4 sections. When a new section is shown, move focus to this new section. This means focus isn't "lost", and users can perceive where they are.

* When a new message is being streamed, focus was moving to the container for the new message and feedback buttons. This is now just moving to the new message - which looks tidier for all users.


## Guidance to review

* To test, you will need to just use keyboard, not mouse. `Tab` to go forwards. `Shift` + `Tab` to go backwards. `Space` to interact with control.
* You should see the focus indicator outlines as you navigate through.
