### PR TITLE
Announce when message streaming has completed to screen-reader users

### DIFF
--- a/django_app/frontend/src/js/chats/streaming.js
+++ b/django_app/frontend/src/js/chats/streaming.js
@@ -71,12 +71,15 @@ class ChatMessage extends HTMLElement {
                 }</markdown-converter>
                 ${
                   !this.dataset.text
-                    ? `<div class="rb-loading-ellipsis govuk-body-s">
+                    ? `
+                      <div class="rb-loading-ellipsis govuk-body-s" aria-label="Loading message">
                         Loading
                         <span aria-hidden="true">.</span>
                         <span aria-hidden="true">.</span>
                         <span aria-hidden="true">.</span>
-                    </div>`
+                      </div>
+                      <div class="rb-loading-complete govuk-visually-hidden" aria-live="assertive"></div>
+                      `
                     : ""
                 }
                 <sources-list></sources-list>
@@ -125,6 +128,7 @@ class ChatMessage extends HTMLElement {
     let responseLoading = /** @type HTMLElement */ (
       this.querySelector(".rb-loading-ellipsis")
     );
+    let responseComplete = this.querySelector(".rb-loading-complete");
     let webSocket = new WebSocket(endPoint);
     let streamedContent = "";
     let sources = [];
@@ -156,6 +160,9 @@ class ChatMessage extends HTMLElement {
 
     webSocket.onclose = (event) => {
       responseLoading.style.display = "none";
+      if (responseComplete) {
+        responseComplete.textContent = "Response complete";
+      }
       if (this.dataset.status !== "stopped") {
         this.dataset.status = "complete";
       }


### PR DESCRIPTION
## Context

When testing with a screen-reader, I noticed it was announced when a new message is loading, but not when it has completed - leaving users to guess when it's complete.


## Changes proposed in this pull request

* Announce "Response complete" to screen-reader users when a response has finished streaming


## Guidance to review

* Check the code looks sensible
* If you can't test with a screen-reader, I understand! And I'd be happy to give you a demo, if you want. But I'm happy it's working.
