### PR TITLE
Update URL when a new chat is created

### DIFF
--- a/django_app/frontend/src/js/chats/streaming.js
+++ b/django_app/frontend/src/js/chats/streaming.js
@@ -314,3 +314,9 @@ class DocumentSelector extends HTMLElement {
   }
 }
 customElements.define("document-selector", DocumentSelector);
+
+// Update URL when a new chat is created
+document.addEventListener("chat-response-end", (evt) => {
+  const sessionId = /** @type{CustomEvent} */ (evt).detail.session_id;
+  window.history.pushState({}, "", `/chats/${sessionId}`);
+});


### PR DESCRIPTION
## Context

Currently, when a new chat is created the URL stays the same. This means that on a page reload it goes back to a new chat, which could be confusing for users.


## Changes proposed in this pull request

Update the URL as soon as we have the new ChatID


## Guidance to review

Start a new chat and check the URL updates. Reloading the page stays on the same chat.
