### PR TITLE
added summarisation_chunk_max_tokens to tf

### DIFF
--- a/infrastructure/aws/data.tf
+++ b/infrastructure/aws/data.tf
@@ -26,6 +26,7 @@ locals {
       "AI__CONDENSE_QUESTION_PROMPT" : var.condense_question_prompt,
       "AI__SUMMARISATION_SYSTEM_PROMPT" : var.summarisation_system_prompt,
       "AI__SUMMARISATION_QUESTION_PROMPT" : var.summarisation_question_prompt,
+      "AI__SUMMARISATION_CHUNK_MAX_TOKENS": var.summarisation_chunk_max_tokens
     }
   )
 

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -341,3 +341,10 @@ variable "embedding_retry_max_seconds" {
   default     = 120
   description = "Maximum number of seconds to wait before retry to external embedding services (rate limiting)"
 }
+
+
+variable "summarisation_chunk_max_tokens" {
+  type        = number
+  default     = 20000
+  description = "Maximum size (in tokens) of chunk used in summarisation"
+}

--- a/redbox-core/redbox/models/settings.py
+++ b/redbox-core/redbox/models/settings.py
@@ -106,8 +106,6 @@ class AISettings(BaseModel):
     rag_num_candidates: int = 10
     rag_desired_chunk_size: int = 300
     elbow_filter_enabled: bool = True
-    summarisation_chunk_max_tokens: int = 20_000
-    summarisation_max_concurrency: int = 128
     chat_system_prompt: str = CHAT_SYSTEM_PROMPT
     chat_question_prompt: str = CHAT_QUESTION_PROMPT
     chat_with_docs_system_prompt: str = CHAT_WITH_DOCS_SYSTEM_PROMPT
@@ -120,6 +118,8 @@ class AISettings(BaseModel):
     condense_question_prompt: str = CONDENSE_QUESTION_PROMPT
     summarisation_system_prompt: str = SUMMARISATION_SYSTEM_PROMPT
     summarisation_question_prompt: str = SUMMARISATION_QUESTION_PROMPT
+    summarisation_chunk_max_tokens: int = 20_000
+    summarisation_max_concurrency: int = 128
     map_system_prompt: str = MAP_SYSTEM_PROMPT
     map_question_prompt: str = MAP_QUESTION_PROMPT
     map_document_prompt: str = MAP_DOCUMENT_PROMPT


### PR DESCRIPTION
## Context

As an Engineer I want to be able to deploy different  `summarisation_chunk_max_tokens` values

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
