### PR TITLE
Add copy-to-clipboard button

### DIFF
--- a/django_app/frontend/src/js/chats.js
+++ b/django_app/frontend/src/js/chats.js
@@ -1,6 +1,7 @@
 import "./web-components/chats/chat-controller.js";
 import "./web-components/chats/chat-message.js";
 import "./web-components/chats/chat-title.js";
+import "./web-components/chats/copy-text.js";
 import "./web-components/chats/document-selector.js";
 import "./web-components/chats/feedback-buttons.js";
 import "./web-components/markdown-converter.js";

--- a/django_app/frontend/src/js/trusted-types.js
+++ b/django_app/frontend/src/js/trusted-types.js
@@ -15,7 +15,8 @@ if (typeof window.trustedTypes !== "undefined") {
             tagName === "sources-list" ||
             tagName === "tool-tip" ||
             tagName === "feedback-buttons" ||
-            tagName === "chat-title",
+            tagName === "chat-title" ||
+            tagName === "copy-text",
           attributeNameCheck: (attr) => true,
           allowCustomizedBuiltInElements: true,
         },

--- a/django_app/frontend/src/js/web-components/chats/copy-text.js
+++ b/django_app/frontend/src/js/web-components/chats/copy-text.js
@@ -2,6 +2,10 @@
 
 class CopyText extends HTMLElement {
   connectedCallback() {
+    if (typeof ClipboardItem === "undefined") {
+      return;
+    }
+
     this.innerHTML = `
         <button class="iai-chat-bubble__citations-button" type="button">
           <svg width="19" height="18" viewBox="0 0 19 18" fill="none" focusable="false" aria-hidden="true">
@@ -12,27 +16,15 @@ class CopyText extends HTMLElement {
         </button>
     `;
 
-    const getTextWithLineBreaks = (element) => {
-      let text = "";
-      element.childNodes.forEach((node) => {
-        if (node.nodeType === Node.TEXT_NODE) {
-          text += node.textContent;
-        } else if (node.nodeType === Node.ELEMENT_NODE) {
-          text += getTextWithLineBreaks(node);
-          if (["P", "DIV", "BR"].includes(node.tagName)) {
-            text += "\n";
-          }
-        }
-      });
-      return text;
-    };
-
     this.querySelector("button")?.addEventListener("click", () => {
       const textEl = this.closest(".iai-chat-bubble")?.querySelector(
         ".iai-chat-bubble__text"
       );
-      const text = getTextWithLineBreaks(textEl);
-      navigator.clipboard.writeText(text || "");
+
+      const type = "text/html";
+      const blob = new Blob([textEl?.innerHTML || ""], { type });
+      const data = [new ClipboardItem({ [type]: blob })];
+      navigator.clipboard.write(data);
     });
   }
 }

--- a/django_app/frontend/src/js/web-components/chats/copy-text.js
+++ b/django_app/frontend/src/js/web-components/chats/copy-text.js
@@ -1,0 +1,39 @@
+// @ts-check
+
+class CopyText extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+        <button class="iai-chat-bubble__citations-button" type="button">
+          <svg width="19" height="18" viewBox="0 0 19 18" fill="none" focusable="false" aria-hidden="true">
+            <path d="M6.875 3H5C4.17157 3 3.5 3.67157 3.5 4.5V15C3.5 15.8284 4.17157 16.5 5 16.5H14C14.8284 16.5 15.5 15.8284 15.5 15V4.5C15.5 3.67157 14.8284 3 14 3H12.125" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <path d="M6.5 4.8V3.375C6.5 3.16789 6.66789 3 6.875 3C7.08211 3 7.25317 2.83203 7.28864 2.62798C7.39976 1.98878 7.83049 0.75 9.5 0.75C11.1695 0.75 11.6002 1.98878 11.7114 2.62798C11.7468 2.83203 11.9179 3 12.125 3C12.3321 3 12.5 3.16789 12.5 3.375V4.8C12.5 5.04853 12.2985 5.25 12.05 5.25H6.95C6.70147 5.25 6.5 5.04853 6.5 4.8Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+          Copy to clipboard
+        </button>
+    `;
+
+    const getTextWithLineBreaks = (element) => {
+      let text = "";
+      element.childNodes.forEach((node) => {
+        if (node.nodeType === Node.TEXT_NODE) {
+          text += node.textContent;
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+          text += getTextWithLineBreaks(node);
+          if (["P", "DIV", "BR"].includes(node.tagName)) {
+            text += "\n";
+          }
+        }
+      });
+      return text;
+    };
+
+    this.querySelector("button")?.addEventListener("click", () => {
+      const textEl = this.closest(".iai-chat-bubble")?.querySelector(
+        ".iai-chat-bubble__text"
+      );
+      const text = getTextWithLineBreaks(textEl);
+      navigator.clipboard.writeText(text || "");
+    });
+  }
+}
+customElements.define("copy-text", CopyText);

--- a/django_app/frontend/src/js/web-components/chats/copy-text.js
+++ b/django_app/frontend/src/js/web-components/chats/copy-text.js
@@ -2,10 +2,6 @@
 
 class CopyText extends HTMLElement {
   connectedCallback() {
-    if (typeof ClipboardItem === "undefined") {
-      return;
-    }
-
     this.innerHTML = `
         <button class="iai-chat-bubble__citations-button" type="button">
           <svg width="19" height="18" viewBox="0 0 19 18" fill="none" focusable="false" aria-hidden="true">
@@ -16,15 +12,22 @@ class CopyText extends HTMLElement {
         </button>
     `;
 
+    const copyToClip = (str) => {
+      function listener(evt) {
+        evt.clipboardData.setData("text/html", str);
+        evt.clipboardData.setData("text/plain", str);
+        evt.preventDefault();
+      }
+      document.addEventListener("copy", listener);
+      document.execCommand("copy");
+      document.removeEventListener("copy", listener);
+    };
+
     this.querySelector("button")?.addEventListener("click", () => {
       const textEl = this.closest(".iai-chat-bubble")?.querySelector(
         ".iai-chat-bubble__text"
       );
-
-      const type = "text/html";
-      const blob = new Blob([textEl?.innerHTML || ""], { type });
-      const data = [new ClipboardItem({ [type]: blob })];
-      navigator.clipboard.write(data);
+      copyToClip(textEl?.innerHTML);
     });
   }
 }

--- a/django_app/frontend/src/js/web-components/chats/sources-list.js
+++ b/django_app/frontend/src/js/web-components/chats/sources-list.js
@@ -42,14 +42,25 @@ class SourcesList extends HTMLElement {
     if (!chatId) {
       return;
     }
-    let link = document.createElement("a");
-    link.classList.add(
-      "iai-chat-bubble__citations-button",
-      "govuk-!-margin-left-2"
-    );
-    link.setAttribute("href", `/citations/${chatId}`);
-    link.textContent = "View information behind this answer";
-    this.querySelector(".iai-display-flex-from-desktop")?.appendChild(link);
+    if (this.sources.length) {
+      const html = `
+        <div class="iai-chat-bubble__citations-button-container">
+          <copy-text></copy-text>
+          <a class="iai-chat-bubble__citations-button" href="/citations/${chatId}">
+            <svg width="20" height="19" viewBox="0 0 20 19" fill="none" focusable="false" aria-hidden="true">
+                <path d="M1.5 9.62502C1.5 9.62502 4.59036 3.55359 10 3.55359C15.4084 3.55359 18.5 9.62502 18.5 9.62502C18.5 9.62502 15.4084 15.6964 10 15.6964C4.59036 15.6964 1.5 9.62502 1.5 9.62502Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                <path d="M9.99993 10.8392C10.322 10.8392 10.6308 10.7113 10.8586 10.4836C11.0863 10.2558 11.2142 9.94698 11.2142 9.62493C11.2142 9.30288 11.0863 8.99402 10.8586 8.7663C10.6308 8.53858 10.322 8.41064 9.99993 8.41064C9.67788 8.41064 9.36902 8.53858 9.1413 8.7663C8.91358 8.99402 8.78564 9.30288 8.78564 9.62493C8.78564 9.94698 8.91358 10.2558 9.1413 10.4836C9.36902 10.7113 9.67788 10.8392 9.99993 10.8392Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            See the response info
+          </a>
+        </div>
+      `;
+      /** @type {HTMLElement} */ (
+        this.querySelector(".iai-display-flex-from-desktop")
+      ).innerHTML += html;
+    } else {
+      this.innerHTML = `<copy-text></copy-text>`;
+    }
   };
 }
 customElements.define("sources-list", SourcesList);

--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -406,3 +406,30 @@ feedback-buttons:last-of-type {
   --iai-background-colour-2: #f8f8f8;
 }
 @import "../node_modules/i.ai-design-system/dist/styles.scss";
+
+.iai-chat-bubble__citations-button-container {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+.iai-chat-bubble__citations-button {
+  align-items: center;
+  background-color: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 0.375rem;
+  margin-top: 0;
+  padding: 0.5rem 0.75rem;
+}
+button.iai-chat-bubble__citations-button {
+  padding: 0.675rem 0.75rem;
+}
+@media (min-width: 1020px) {
+  .iai-chat-bubble__citations-button-container {
+    margin-left: 1rem;
+    margin-top: 0;
+  }
+}

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -62,10 +62,20 @@
       </li>
       {% endfor %}
     </ul>
-    <a class="iai-chat-bubble__citations-button govuk-!-margin-left-2" href="{{url('citations', id)}}">View information
-      behind this answer</a>
+    <div class="iai-chat-bubble__citations-button-container">
+      <copy-text></copy-text>
+      <a class="iai-chat-bubble__citations-button" href="{{url('citations', id)}}">
+        <svg width="20" height="19" viewBox="0 0 20 19" fill="none" focusable="false" aria-hidden="true">
+            <path d="M1.5 9.62502C1.5 9.62502 4.59036 3.55359 10 3.55359C15.4084 3.55359 18.5 9.62502 18.5 9.62502C18.5 9.62502 15.4084 15.6964 10 15.6964C4.59036 15.6964 1.5 9.62502 1.5 9.62502Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M9.99993 10.8392C10.322 10.8392 10.6308 10.7113 10.8586 10.4836C11.0863 10.2558 11.2142 9.94698 11.2142 9.62493C11.2142 9.30288 11.0863 8.99402 10.8586 8.7663C10.6308 8.53858 10.322 8.41064 9.99993 8.41064C9.67788 8.41064 9.36902 8.53858 9.1413 8.7663C8.91358 8.99402 8.78564 9.30288 8.78564 9.62493C8.78564 9.94698 8.91358 10.2558 9.1413 10.4836C9.36902 10.7113 9.67788 10.8392 9.99993 10.8392Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        See the response info
+      </a>
+    </div>
   </div>
   <br />
+  {% elif role == "ai" %}
+    <copy-text></copy-text>
   {% endif %}
 </div>
 

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -294,7 +294,7 @@ class ChatMessage:
     chats_page: "ChatsPage" = field(repr=False)
 
     def navigate_to_citations(self) -> "CitationsPage":
-        self.element.locator(".iai-chat-bubble__citations-button").click()
+        self.element.locator("a.iai-chat-bubble__citations-button").click()
         return CitationsPage(self.chats_page.page)
 
     @classmethod


### PR DESCRIPTION
## Context

This adds a copy-to-clipboard button, either like this:

<img src="https://github.com/user-attachments/assets/576e6433-35ad-4b99-bbf0-5fb7742bf814" width="400" alt="screenshot show new button below the existing citations button"/>

Or, if no citations, like this:

<img src="https://github.com/user-attachments/assets/8005d01e-a744-472a-b9ee-4a3858eb49dd" width="400" alt="screenshot show new button below the response"/>



## Guidance to review

Try the button. Paste into something else, e.g. a Google doc. You can also paste directly into the "Message Redbox" input, but this won't preserve formatting.


## Relevant links


## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
