### PR TITLE
Remove makefile targets and add ecs scaledown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,12 +234,12 @@ tf_init: ## Initialise terraform
 .PHONY: tf_plan
 tf_plan: ## Plan terraform
 	make tf_set_workspace && \
-	terraform -chdir=./infrastructure/aws/$(instance) plan -var-file=$(CONFIG_DIR)/${env}-input-params.tfvars ${tf_build_args} -target=module.lambda-cleanup
+	terraform -chdir=./infrastructure/aws/$(instance) plan -var-file=$(CONFIG_DIR)/${env}-input-params.tfvars ${tf_build_args}
 
 .PHONY: tf_apply
 tf_apply: ## Apply terraform
 	make tf_set_workspace && \
-	terraform -chdir=./infrastructure/aws/$(instance) apply -var-file=$(CONFIG_DIR)/${env}-input-params.tfvars ${tf_build_args} ${args} -target=module.lambda-cleanup -target=module.rds -target=aws_security_group_rule.lambda_to_rds_egress -target=module.elasticache -target=module.lambda-test -target=module.lambda -target=aws_security_group.service_security_group -target=aws_security_group_rule.lambda_to_443_egress
+	terraform -chdir=./infrastructure/aws/$(instance) apply -var-file=$(CONFIG_DIR)/${env}-input-params.tfvars ${tf_build_args} ${args}
 
 .PHONY: tf_init_universal
 tf_init_universal: ## Initialise terraform

--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -106,6 +106,7 @@ module "django-app" {
   ip_whitelist                 = var.external_ips
   environment_variables        = local.django_app_environment_variables
   secrets                      = local.reconstructed_django_secrets
+  auto_scale_off_peak_times    = true
 }
 
 
@@ -140,6 +141,7 @@ module "core_api" {
   environment_variables        = local.core_api_environment_variables
   secrets                      = local.reconstructed_core_secrets
   ephemeral_storage            = 30
+  auto_scale_off_peak_times    = true
 }
 
 
@@ -167,6 +169,7 @@ module "worker" {
   secrets                      = local.reconstructed_worker_secrets
   http_healthcheck             = false
   ephemeral_storage            = 30
+  auto_scale_off_peak_times    = true
 }
 
 


### PR DESCRIPTION
## Context

ECS services running on the weekend and at night shouldn't scale even under demand as it's unlikely to be legitimate traffic. Change the ECS tasks to include a scheduled action that scales down and up depending on peak times

## Changes proposed in this pull request

- Added bool to tell each ECS service to scale

## Guidance to review

Check the resources exist in terraform (currently no way to view in aws console)

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
