### PR TITLE
Refactor/generalise chat runnables

### DIFF
--- a/core-api/tests/test_runnables.py
+++ b/core-api/tests/test_runnables.py
@@ -1,5 +1,8 @@
 import pytest
-from core_api.build_chains import build_condense_retrieval_chain, build_retrieval_chain, build_summary_chain
+from core_api.build_chains import (build_chat_chain,
+                                   build_chat_with_docs_chain,
+                                   build_condense_retrieval_chain,
+                                   build_retrieval_chain, build_summary_chain)
 from core_api.dependencies import get_parameterised_retriever, get_tokeniser
 
 from redbox.api.runnables import make_chat_prompt_from_messages_runnable
@@ -156,3 +159,47 @@ def test_summary_runnable_small_file(all_chunks_retriever, mock_llm, chunked_fil
 
     assert response["response"] == "<<TESTING>>"
     assert response["route_name"] == ChatRoute.summarise
+
+
+def test_chat_runnable(mock_llm, chunked_file, env):
+    chain = build_chat_chain(llm=mock_llm, tokeniser=get_tokeniser(), env=env)
+
+    previous_history = [
+        {"text": "Lorem ipsum dolor sit amet.", "role": "user"},
+        {"text": "Consectetur adipiscing elit.", "role": "ai"},
+        {"text": "Donec cursus nunc tortor.", "role": "user"},
+    ]
+
+    response = chain.invoke(
+        input=ChainInput(
+            question="Who are all these people?",
+            chat_history=previous_history,
+            file_uuids=[str(chunked_file.uuid)],
+            user_uuid=str(chunked_file.creator_user_uuid),
+        ).dict()
+    )
+
+    assert response["response"] == "<<TESTING>>"
+    assert response["route_name"] == ChatRoute.chat
+
+
+def test_chat_with_documents_runnable(all_chunks_retriever, mock_llm, chunked_file, env):
+    chain = build_chat_with_docs_chain(llm=mock_llm, all_chunks_retriever=all_chunks_retriever, tokeniser=get_tokeniser(), env=env)
+
+    previous_history = [
+        {"text": "Lorem ipsum dolor sit amet.", "role": "user"},
+        {"text": "Consectetur adipiscing elit.", "role": "ai"},
+        {"text": "Donec cursus nunc tortor.", "role": "user"},
+    ]
+
+    response = chain.invoke(
+        input=ChainInput(
+            question="Who are all these people?",
+            chat_history=previous_history,
+            file_uuids=[str(chunked_file.uuid)],
+            user_uuid=str(chunked_file.creator_user_uuid),
+        ).dict()
+    )
+
+    assert response["response"] == "<<TESTING>>"
+    assert response["route_name"] == ChatRoute.chat_with_docs

--- a/redbox-core/redbox/api/runnables.py
+++ b/redbox-core/redbox/api/runnables.py
@@ -1,12 +1,12 @@
 from functools import partial, reduce
-from typing import Any
 from logging import getLogger
+from typing import Any
 
+from kneed import KneeLocator
 from langchain_core.documents.base import Document
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.runnables import RunnableLambda, RunnablePassthrough, chain, Runnable
+from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrough, chain
 from tiktoken import Encoding
-from kneed import KneeLocator
 
 from redbox.api.format import reduce_chunks_by_tokens
 from redbox.models import ChatResponse

--- a/redbox-core/redbox/models/settings.py
+++ b/redbox-core/redbox/models/settings.py
@@ -79,7 +79,7 @@ CONDENSE_SYSTEM_PROMPT = (
 
 CHAT_QUESTION_PROMPT = "{question}\n=========\n Response: "
 
-CHAT_WITH_DOCS_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+CHAT_WITH_DOCS_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {formatted_documents} \n\n Answer: "
 
 CHAT_WITH_DOCS_REDUCE_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {summaries} \n\n Answer: "
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Make `build_chat_with_docs_chain` cleaner and add unit tests for chat as default

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Refactored `build_chat_with_docs_chain` to make code more readable and added unit tests for `build_chat_chain` and `build_chat_with_docs_chain`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
