### PR TITLE
Ignore errored and deleted files in file deletion command

### DIFF
--- a/django_app/redbox_app/redbox_core/management/commands/delete_expired_data.py
+++ b/django_app/redbox_app/redbox_core/management/commands/delete_expired_data.py
@@ -22,11 +22,12 @@ class Command(BaseCommand):
 
     def handle(self, *_args, **_kwargs):
         cutoff_date = timezone.now() - timedelta(seconds=settings.FILE_EXPIRY_IN_SECONDS)
+        statuses_to_ignore = [StatusEnum.deleted, StatusEnum.errored]
 
         self.stdout.write(self.style.NOTICE(f"Deleting Files expired before {cutoff_date}"))
         counter = 0
 
-        for file in File.objects.filter(last_referenced__lt=cutoff_date):
+        for file in File.objects.filter(last_referenced__lt=cutoff_date).exclude(status__in=statuses_to_ignore):
             logger.debug(
                 "Deleting file object %s, last_referenced %s",
                 file,


### PR DESCRIPTION
## Context
Bugfix for the 'delete file' management command, so we don't get a load of errors checking for already-deleted files.

## Changes proposed in this pull request
Checks whether files have previously been deleted from core-api before trying to delete them.

## Guidance to review


## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
