### PR TITLE
File reingestion management command

### DIFF
--- a/django_app/redbox_app/redbox_core/management/commands/reingest_files.py
+++ b/django_app/redbox_app/redbox_core/management/commands/reingest_files.py
@@ -19,10 +19,7 @@ class Command(BaseCommand):
 
     def handle(self, *_args, **_kwargs):
         self.stdout.write(self.style.NOTICE("Reingesting active files from Django"))
-        counters = {
-            "success": 0,
-            "errors": 0,
-        }
+        successes, errors = 0, 0
 
         for file in File.objects.exclude(status__in=INACTIVE_STATUSES):
             logger.debug("Reingesting file object %s", file)
@@ -34,15 +31,13 @@ class Command(BaseCommand):
                 logger.exception("Error reingesting file object %s using core-api", file, exc_info=e)
                 file.status = StatusEnum.errored
                 file.save()
-                counters["errors"] += 1
+                errors += 1
 
             else:
                 file.status = StatusEnum.uploaded
                 file.save()
-                counters["success"] += 1
+                successes += 1
 
         self.stdout.write(
-            self.style.NOTICE(
-                f"Successfully reuploaded {counters["success"]} files and failed to reupload {counters["errors"]} files"
-            )
+            self.style.NOTICE(f"Successfully reuploaded {successes} files and failed to reupload {errors} files")
         )

--- a/django_app/redbox_app/redbox_core/management/commands/reingest_files.py
+++ b/django_app/redbox_app/redbox_core/management/commands/reingest_files.py
@@ -1,0 +1,48 @@
+import logging
+
+from django.conf import settings
+from django.core.management import BaseCommand
+from requests.exceptions import RequestException
+
+from redbox_app.redbox_core.client import CoreApiClient
+from redbox_app.redbox_core.models import INACTIVE_STATUSES, File, StatusEnum
+
+logger = logging.getLogger(__name__)
+core_api = CoreApiClient(host=settings.CORE_API_HOST, port=settings.CORE_API_PORT)
+
+
+class Command(BaseCommand):
+    help = """This is an ad-hoc command when changes to the AI pipeline (e.g. a new embedding strategy)
+    mean we need to regenerate chunks for all the current files.
+
+    It attempts to reupload file data to core-api for reingestion."""
+
+    def handle(self, *_args, **_kwargs):
+        self.stdout.write(self.style.NOTICE("Reingesting active files from Django"))
+        counters = {
+            "success": 0,
+            "errors": 0,
+        }
+
+        for file in File.objects.exclude(status__in=INACTIVE_STATUSES):
+            logger.debug("Reingesting file object %s", file)
+
+            try:
+                core_api.reingest_file(file.core_file_uuid, file.user)
+
+            except RequestException as e:
+                logger.exception("Error reingesting file object %s using core-api", file, exc_info=e)
+                file.status = StatusEnum.errored
+                file.save()
+                counters["errors"] += 1
+
+            else:
+                file.status = StatusEnum.uploaded
+                file.save()
+                counters["success"] += 1
+
+        self.stdout.write(
+            self.style.NOTICE(
+                f"Successfully reuploaded {counters["success"]} files and failed to reupload {counters["errors"]} files"
+            )
+        )

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -131,6 +131,9 @@ class StatusEnum(models.TextChoices):
     errored = "errored"
 
 
+INACTIVE_STATUSES = [StatusEnum.deleted, StatusEnum.errored, StatusEnum.unknown]
+
+
 class File(UUIDPrimaryKeyBase, TimeStampedModel):
     status = models.CharField(choices=StatusEnum.choices, null=False, blank=False)
     original_file = models.FileField(storage=settings.STORAGES["default"]["BACKEND"])

--- a/django_app/tests/management/test_commands.py
+++ b/django_app/tests/management/test_commands.py
@@ -90,8 +90,9 @@ def test_delete_expired_files(
     mock_file.last_referenced = last_referenced
     mock_file.save()
 
+    matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-")
     requests_mock.delete(
-        f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{mock_file.core_file_uuid}",
+        matcher,
         status_code=201,
         json={
             "key": mock_file.original_file_name,
@@ -115,6 +116,17 @@ def test_delete_expired_files_with_api_error(uploaded_file: File, requests_mock:
     mock_file.last_referenced = EXPIRED_FILE_DATE
     mock_file.save()
 
+    matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-")
+
+    requests_mock.delete(
+        matcher,
+        status_code=201,
+        json={
+            "key": mock_file.original_file_name,
+            "bucket": settings.BUCKET_NAME,
+            "uuid": str(uuid.uuid4()),
+        },
+    )
     (
         requests_mock.delete(
             f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{mock_file.core_file_uuid}",
@@ -139,8 +151,10 @@ def test_delete_expired_files_with_s3_error(uploaded_file: File, requests_mock: 
         mock_file.last_referenced = EXPIRED_FILE_DATE
         mock_file.save()
 
+        matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-")
+
         requests_mock.delete(
-            f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{mock_file.core_file_uuid}",
+            matcher,
             status_code=201,
             json={
                 "key": mock_file.original_file_name,


### PR DESCRIPTION
## Context
Now that we're running management tasks through ECS commands, this gives us a new option for running reingestion to core-api. Using Django admin for this task caused timeout problems if done in batches that were too large. If successful, I will remove the old Admin command in a later PR

## Changes proposed in this pull request
* Adds and tests a new 'reingest files' management command.
* updates the expired file deletion management command using the new common `INACTIVE_STATUSES` constant
* updates the expired file deletion tests so that the requests mock takes into account other matching files - avoiding annoying errors when testing locally.


## Guidance to review
Does the command and its test make sense?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
