### PR TITLE
Make select_document message more general

### DIFF
--- a/django_app/redbox_app/redbox_core/error_messages.py
+++ b/django_app/redbox_app/redbox_core/error_messages.py
@@ -4,5 +4,5 @@ CORE_ERROR_MESSAGE = (
     "There was an unexpected error communicating with Redbox. "
     'Please try again, and contact <a href="/support/">support</a> if the problem persists.'
 )
-SELECT_DOCUMENT = "Please select a document for summarisation."
+SELECT_DOCUMENT = "Please select a document."
 QUESTION_TOO_LONG = "Sorry, this question is too long. Please try again with a shorter question."


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
If NoDocumentsSelected exception is triggered, currently the message the user receives is specific to summarisation, however, this can happen in other situations, so we need to make it more general.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Minor change to `SELECT_DOCUMENT` message.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
