### PR TITLE
Fix errors on file upload.

### DIFF
--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -59,9 +59,9 @@ class CoreChatResponse:
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass(frozen=True)
 class FileStatus:
-    processing_status: Literal[
-        "uploaded", "parsing", "chunking", "embedding", "indexing", "complete", "unknown", "errored"
-    ]
+    processing_status: (
+        Literal["uploaded", "parsing", "chunking", "embedding", "indexing", "complete", "unknown", "errored"] | None
+    )
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)

--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -193,7 +193,7 @@ def file_status_api_view(request: HttpRequest) -> JsonResponse:
         logger.error("Error getting file object information - no file ID provided %s.")
         return JsonResponse({"status": StatusEnum.unknown.label})
     try:
-        file = get_object_or_404(File, id=file_id)
+        file: File = get_object_or_404(File, id=file_id)
     except File.DoesNotExist as ex:
         logger.exception("File object information not found in django - file does not exist %s.", file_id, exc_info=ex)
         return JsonResponse({"status": StatusEnum.unknown.label})
@@ -205,6 +205,6 @@ def file_status_api_view(request: HttpRequest) -> JsonResponse:
             file.status = StatusEnum.unknown.label
             file.save()
         return JsonResponse({"status": file.status})
-    file.status = core_file_status_response.processing_status
+    file.status = core_file_status_response.processing_status or StatusEnum.unknown.name
     file.save()
     return JsonResponse({"status": file.get_status_text()})

--- a/redbox-core/redbox/models/file.py
+++ b/redbox-core/redbox/models/file.py
@@ -148,7 +148,7 @@ class FileStatus(BaseModel):
     """Status of a file."""
 
     file_uuid: UUID
-    processing_status: ProcessingStatusEnum
+    processing_status: ProcessingStatusEnum | None
     chunk_statuses: None = Field(default=None, description="deprecated, see processing_status")
 
 


### PR DESCRIPTION
## Context

https://technologyprogramme.atlassian.net/browse/REDBOX-566

## Changes proposed in this pull request

The ['File' model in 'redbox-core/redbox/models/file.py'](https://github.com/i-dot-ai/redbox/blob/main/redbox-core/redbox/models/file.py#L28) is optional - and for a short period we indeed get `None` back from Elastic. We need to accommodate this in `core-api` and `django-app`.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
