### PR TITLE
Made routable chains runnables again to restore streaming

### DIFF
--- a/core-api/core_api/routes/chat.py
+++ b/core-api/core_api/routes/chat.py
@@ -55,7 +55,7 @@ async def route_chat(
     # Match keyword
     route_match = re_keyword_pattern.search(question)
     route_name = route_match.group()[1:] if route_match else None
-    selected_chain = routable_chains.get(route_name, select_chat_chain(chat_request, routable_chains))
+    selected_chain, description = routable_chains.get(route_name, select_chat_chain(chat_request, routable_chains))
 
     params = ChainInput(
         question=chat_request.message_history[-1].text,
@@ -85,10 +85,10 @@ async def rag_chat(
 
 @chat_app.get("/tools", tags=["chat"])
 async def available_tools(
-    routable_chains: Annotated[dict[str, Tool], Depends(get_routable_chains)],
+    routable_chains: Annotated[dict[str, tuple[Runnable, str]], Depends(get_routable_chains)],
 ):
     """REST endpoint. Get a mapping of all tools available via chat."""
-    return [{"name": chat_tool.name, "description": chat_tool.description} for chat_tool in routable_chains.values()]
+    return [{"name": name, "description": tool[1]} for (name,tool) in routable_chains.items()]
 
 
 @chat_app.websocket("/rag")

--- a/core-api/core_api/routes/chat.py
+++ b/core-api/core_api/routes/chat.py
@@ -88,7 +88,7 @@ async def available_tools(
     routable_chains: Annotated[dict[str, tuple[Runnable, str]], Depends(get_routable_chains)],
 ):
     """REST endpoint. Get a mapping of all tools available via chat."""
-    return [{"name": name, "description": tool[1]} for (name,tool) in routable_chains.items()]
+    return [{"name": name, "description": tool[1]} for (name, tool) in routable_chains.items()]
 
 
 @chat_app.websocket("/rag")

--- a/core-api/core_api/semantic_routes.py
+++ b/core-api/core_api/semantic_routes.py
@@ -8,7 +8,6 @@ from core_api.build_chains import (
 )
 from fastapi import Depends
 from langchain_core.runnables import Runnable
-from langchain_community.tools import Tool
 
 from redbox.models.chat import ChatRoute
 from redbox.models.chain import ChainInput
@@ -60,5 +59,5 @@ def get_routable_chains(
                 "Search for an answer to a question in provided documents",
             ),
         )
-        __routable_chains = {name: (runnable,description) for (name,runnable,description) in chat_tools}
+        __routable_chains = {name: (runnable, description) for (name, runnable, description) in chat_tools}
     return __routable_chains

--- a/core-api/core_api/semantic_routes.py
+++ b/core-api/core_api/semantic_routes.py
@@ -35,30 +35,30 @@ def get_routable_chains(
     condense_chain: Annotated[Runnable, Depends(build_condense_retrieval_chain)],
     chat_chain: Annotated[Runnable, Depends(build_chat_chain)],
     chat_with_docs_chain: Annotated[Runnable, Depends(build_chat_with_docs_chain)],
-) -> dict[str, Tool]:
+) -> dict[str, tuple[Runnable, str]]:
     global __routable_chains  # noqa: PLW0603
     if not __routable_chains:
         chat_tools = (
-            as_chat_tool(
-                name=ChatRoute.info,
-                runnable=build_static_response_chain(INFO_RESPONSE, ChatRoute.info),
-                description="Give helpful information about Redbox",
+            (
+                ChatRoute.info,
+                build_static_response_chain(INFO_RESPONSE, ChatRoute.info),
+                "Give helpful information about Redbox",
             ),
-            as_chat_tool(
-                name=ChatRoute.chat,
-                runnable=chat_chain,
-                description="Answer questions as a helpful assistant",
+            (
+                ChatRoute.chat,
+                chat_chain,
+                "Answer questions as a helpful assistant",
             ),
-            as_chat_tool(
-                name=ChatRoute.chat_with_docs,
-                runnable=chat_with_docs_chain,
-                description="Answer questions as a helpful assistant using the documents provided",
+            (
+                ChatRoute.chat_with_docs,
+                chat_with_docs_chain,
+                "Answer questions as a helpful assistant using the documents provided",
             ),
-            as_chat_tool(
-                name=ChatRoute.search,
-                runnable=condense_chain,
-                description="Search for an answer to a question in provided documents",
+            (
+                ChatRoute.search,
+                condense_chain,
+                "Search for an answer to a question in provided documents",
             ),
         )
-        __routable_chains = {chat_tool.name: chat_tool for chat_tool in chat_tools}
+        __routable_chains = {name: (runnable,description) for (name,runnable,description) in chat_tools}
     return __routable_chains

--- a/core-api/tests/test_runnables.py
+++ b/core-api/tests/test_runnables.py
@@ -116,54 +116,6 @@ def test_condense_runnable(mock_llm, chunked_file, env):
     } == all_results_file_uuids, f"Expected {str(chunked_file.uuid)} in {all_results_file_uuids}"
 
 
-def test_summary_runnable_large_file(all_chunks_retriever, mock_llm, large_chunked_file, env):
-    chain = build_summary_chain(
-        llm=mock_llm, all_chunks_retriever=all_chunks_retriever, tokeniser=get_tokeniser(), env=env
-    )
-
-    previous_history = [
-        {"text": "Lorem ipsum dolor sit amet.", "role": "user"},
-        {"text": "Consectetur adipiscing elit.", "role": "ai"},
-        {"text": "Donec cursus nunc tortor.", "role": "user"},
-    ]
-
-    response = chain.invoke(
-        input=ChainInput(
-            question="Who are all these people?",
-            chat_history=previous_history,
-            file_uuids=[str(large_chunked_file.uuid)],
-            user_uuid=str(large_chunked_file.creator_user_uuid),
-        ).dict()
-    )
-
-    assert response["response"] == "<<TESTING>>"
-    assert response["route_name"] == ChatRoute.map_reduce_summarise, response["route_name"]
-
-
-def test_summary_runnable_small_file(all_chunks_retriever, mock_llm, chunked_file, env):
-    chain = build_summary_chain(
-        llm=mock_llm, all_chunks_retriever=all_chunks_retriever, tokeniser=get_tokeniser(), env=env
-    )
-
-    previous_history = [
-        {"text": "Lorem ipsum dolor sit amet.", "role": "user"},
-        {"text": "Consectetur adipiscing elit.", "role": "ai"},
-        {"text": "Donec cursus nunc tortor.", "role": "user"},
-    ]
-
-    response = chain.invoke(
-        input=ChainInput(
-            question="Who are all these people?",
-            chat_history=previous_history,
-            file_uuids=[str(chunked_file.uuid)],
-            user_uuid=str(chunked_file.creator_user_uuid),
-        ).dict()
-    )
-
-    assert response["response"] == "<<TESTING>>"
-    assert response["route_name"] == ChatRoute.summarise
-
-
 def test_chat_runnable(mock_llm, chunked_file, env):
     chain = build_chat_chain(llm=mock_llm, tokeniser=get_tokeniser(), env=env)
 

--- a/core-api/tests/test_runnables.py
+++ b/core-api/tests/test_runnables.py
@@ -4,7 +4,6 @@ from core_api.build_chains import (
     build_chat_with_docs_chain,
     build_condense_retrieval_chain,
     build_retrieval_chain,
-    build_summary_chain,
 )
 from core_api.dependencies import get_parameterised_retriever, get_tokeniser
 


### PR DESCRIPTION
## Context

Streaming isn't working, all data is returned in the first message.

## Changes proposed in this pull request

Returning our routable_chains to be runnables rather than tools. Tools implement the streaming functions of the Runnable interface naively, without actually streaming, we need to stick with the actual runnables to enable use of streaming

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
