### PR TITLE
Copy AI responses both formatted and unformatted.

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/copy-text.js
+++ b/django_app/frontend/src/js/web-components/chats/copy-text.js
@@ -12,10 +12,10 @@ class CopyText extends HTMLElement {
         </button>
     `;
 
-    const copyToClip = (str) => {
+    const copyToClip = (html, text) => {
       function listener(evt) {
-        evt.clipboardData.setData("text/html", str);
-        evt.clipboardData.setData("text/plain", str);
+        evt.clipboardData.setData("text/html", html);
+        evt.clipboardData.setData("text/plain", text);
         evt.preventDefault();
       }
       document.addEventListener("copy", listener);
@@ -27,7 +27,7 @@ class CopyText extends HTMLElement {
       const textEl = this.closest(".iai-chat-bubble")?.querySelector(
         ".iai-chat-bubble__text"
       );
-      copyToClip(textEl?.innerHTML);
+      copyToClip(textEl?.innerHTML, textEl?.innerText);
     });
   }
 }


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Make the copy button copy both formatted and unformatted text, so you can paste into Word or similar and get formatted text, or into a plain text editor and get plain text without Markup.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
