### PR TITLE
Update tooltips to remove reference to @summarise tool, which no…

### DIFF
--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -15,10 +15,9 @@
         <li class="iai-chat-bubble__route-list-item">I can <strong>@chat</strong> about general questions, not related
           to your documents</li>
         <li class="iai-chat-bubble__route-list-item">I can <strong>@chat/documents</strong> over selected documents and
-          do Q&amp;A on them, extract information, summarise and more!</li>
+          do Q&amp;A on them, generate summaries, extract information and more!</li>
         <li class="iai-chat-bubble__route-list-item">I can help you <strong>@search</strong> over selected documents and
           do Q&amp;A on them, with citations</li>
-        <li class="iai-chat-bubble__route-list-item">I can help you <strong>@summarise</strong> selected documents</li>
       </ul>
     </div>
   </tool-tip>
@@ -66,8 +65,12 @@
       <copy-text></copy-text>
       <a class="iai-chat-bubble__citations-button" href="{{url('citations', id)}}">
         <svg width="20" height="19" viewBox="0 0 20 19" fill="none" focusable="false" aria-hidden="true">
-            <path d="M1.5 9.62502C1.5 9.62502 4.59036 3.55359 10 3.55359C15.4084 3.55359 18.5 9.62502 18.5 9.62502C18.5 9.62502 15.4084 15.6964 10 15.6964C4.59036 15.6964 1.5 9.62502 1.5 9.62502Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M9.99993 10.8392C10.322 10.8392 10.6308 10.7113 10.8586 10.4836C11.0863 10.2558 11.2142 9.94698 11.2142 9.62493C11.2142 9.30288 11.0863 8.99402 10.8586 8.7663C10.6308 8.53858 10.322 8.41064 9.99993 8.41064C9.67788 8.41064 9.36902 8.53858 9.1413 8.7663C8.91358 8.99402 8.78564 9.30288 8.78564 9.62493C8.78564 9.94698 8.91358 10.2558 9.1413 10.4836C9.36902 10.7113 9.67788 10.8392 9.99993 10.8392Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          <path
+            d="M1.5 9.62502C1.5 9.62502 4.59036 3.55359 10 3.55359C15.4084 3.55359 18.5 9.62502 18.5 9.62502C18.5 9.62502 15.4084 15.6964 10 15.6964C4.59036 15.6964 1.5 9.62502 1.5 9.62502Z"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          <path
+            d="M9.99993 10.8392C10.322 10.8392 10.6308 10.7113 10.8586 10.4836C11.0863 10.2558 11.2142 9.94698 11.2142 9.62493C11.2142 9.30288 11.0863 8.99402 10.8586 8.7663C10.6308 8.53858 10.322 8.41064 9.99993 8.41064C9.67788 8.41064 9.36902 8.53858 9.1413 8.7663C8.91358 8.99402 8.78564 9.30288 8.78564 9.62493C8.78564 9.94698 8.91358 10.2558 9.1413 10.4836C9.36902 10.7113 9.67788 10.8392 9.99993 10.8392Z"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
         See the response info
       </a>
@@ -75,7 +78,7 @@
   </div>
   <br />
   {% elif role == "ai" %}
-    <copy-text></copy-text>
+  <copy-text></copy-text>
   {% endif %}
 </div>
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We want the tooltips to reflect accurately the tools available to the user. We have removed the `@summarise` tool, but it was still referred to in tooltips
## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
This PR removes reference to `@summarise` in the tooltips
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
