### PR TITLE
feature/extend-environment-variables

### DIFF
--- a/infrastructure/aws/data.tf
+++ b/infrastructure/aws/data.tf
@@ -67,6 +67,8 @@ locals {
     "ENVIRONMENT" : upper(terraform.workspace),
     "DEBUG" : terraform.workspace == "dev",
     "AWS_REGION" : var.region,
+    "worker_ingest_min_chunk_size": var.worker_ingest_min_chunk_size,
+    "worker_ingest_max_chunk_size": var.worker_ingest_max_chunk_size,
   }
 
   core_secrets = {

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -359,3 +359,16 @@ variable "embedding_retry_max_seconds" {
   description = "Maximum number of seconds to wait before retry to external embedding services (rate limiting)"
 }
 
+variable "worker_ingest_min_chunk_size" {
+  type        = number
+  default     = 600
+  description = "Minimum size of chunks to be produced by the worker"
+}
+
+
+variable "worker_ingest_max_chunk_size" {
+  type        = number
+  default     = 800
+  description = "Maximum size of chunks to be produced by the worker"
+}
+


### PR DESCRIPTION
## Context

As an Engineer I want to added worker_ingest_min_chunk_size and worker_ingest_max_chunk_size to the environment variables so that i can adjust them without having to rebuild the image

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
