### PR TITLE
Split django ecs task and added up/down scheduling

### DIFF
--- a/infrastructure/aws/data.tf
+++ b/infrastructure/aws/data.tf
@@ -95,10 +95,25 @@ locals {
     "AZURE_OPENAI_ENDPOINT" : var.azure_openai_endpoint,
   }
 
-  reconstructed_worker_secrets = [for k, _ in local.worker_secrets : { name = k, valueFrom = "${aws_secretsmanager_secret.worker-secret.arn}:${k}::" }]
-  reconstructed_core_secrets   = [for k, _ in local.core_secrets : { name = k, valueFrom = "${aws_secretsmanager_secret.core-api-secret.arn}:${k}::" }]
-  reconstructed_django_secrets = [for k, _ in local.django_app_secrets : { name = k, valueFrom = "${aws_secretsmanager_secret.django-app-secret.arn}:${k}::" }]
-  reconstructed_django_command_secrets = [for k, _ in local.django_app_secrets : { name = k, valueFrom = "${aws_secretsmanager_secret.django-command-secret.arn}:${k}::" }]
+  reconstructed_worker_secrets = [
+    for k, _ in local.worker_secrets :{ name = k, valueFrom = "${aws_secretsmanager_secret.worker-secret.arn}:${k}::" }
+  ]
+  reconstructed_core_secrets = [
+    for k, _ in local.core_secrets :{ name = k, valueFrom = "${aws_secretsmanager_secret.core-api-secret.arn}:${k}::" }
+  ]
+  reconstructed_django_secrets = [
+    for k, _ in local.django_app_secrets :
+    { name = k, valueFrom = "${aws_secretsmanager_secret.django-app-secret.arn}:${k}::" }
+  ]
+  reconstructed_django_command_secrets = [
+    for k, _ in local.django_app_secrets :
+    { name = k, valueFrom = "${aws_secretsmanager_secret.django-command-secret.arn}:${k}::" }
+  ]
+
+  django_command_roles_map = {
+    for i, v in module.django-command :
+    "django-command-${i}" => v.ecs_task_execution_exec_role_name
+  }
 }
 
 data "terraform_remote_state" "vpc" {

--- a/infrastructure/aws/iam.tf
+++ b/infrastructure/aws/iam.tf
@@ -52,14 +52,13 @@ resource "aws_iam_policy" "redbox_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "redbox_role_policy" {
-  for_each = tomap(
+  for_each = merge(tomap(
     {
       "core-api" = module.core_api.ecs_task_execution_exec_role_name,
       "worker"   = module.worker.ecs_task_execution_exec_role_name,
       "django"   = module.django-app.ecs_task_execution_exec_role_name,
-      "django-command"   = module.django-command.ecs_task_execution_exec_role_name,
-    }
-  )
+    },
+  ), local.django_command_roles_map)
   role       = each.value
   policy_arn = aws_iam_policy.redbox_policy.arn
 }

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -25,9 +25,21 @@ variable "developer_ips" {
 }
 
 variable "django_command" {
-  type        = string
-  default     = "delete_expired_data"
-  description = "Name of Django management to be run. Use with caution"
+  type = list(object({
+    command : string,
+    task_name : string,
+    min_tasks : number,
+    max_tasks : number,
+    mem : number,
+    cpu : number,
+    schedule_up: optional(string),
+    schedule_down: optional(string),
+  }))
+  default = [
+    { command : "delete_expired_data", task_name : "delete", min_tasks : 0, max_tasks : 0, mem : 512, cpu : 256, schedule_up: "cron(00 02 * * ? *)", schedule_down: "cron(30 02 * * ? *)" }, # default to not running, every day at 2-2:30am
+    { command : "reingest_files", task_name : "reingest", min_tasks : 0, max_tasks : 0, mem : 512, cpu : 256 } # default to not running, no schedule, manually triggered
+  ]
+  description = "An object describing the django command to run"
 }
 
 variable "django_secret_key" {
@@ -365,10 +377,8 @@ variable "worker_ingest_min_chunk_size" {
   description = "Minimum size of chunks to be produced by the worker"
 }
 
-
 variable "worker_ingest_max_chunk_size" {
   type        = number
   default     = 800
   description = "Maximum size of chunks to be produced by the worker"
 }
-


### PR DESCRIPTION
## Context

The management commands we're doing could do with going on a schedule

I'm not sure how effective this will be at stopping them, `desired_count` may override it, but it's hard to test because of not being able to see the schedules in aws console

## Changes proposed in this pull request

- Changed `django_command` variable to be an object to create each task from
- Updated consuming resources of django-command module
- Added var to pass through to core infra

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
