### PR TITLE
REDBOX-561 - Add Cache-control: no-store header to all responses.

### DIFF
--- a/.github/workflows/django-checks.yml
+++ b/.github/workflows/django-checks.yml
@@ -17,6 +17,7 @@ on:
       - 'hotfix/**'
       - 'develop'
       - 'dependabot/**'
+      - 'security/**'
   workflow_dispatch:
 
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,6 +12,7 @@ on:
       - 'bugfix/**'
       - 'hotfix/**'
       - 'dependabot/**'
+      - 'security/**'
       - 'develop'
   workflow_dispatch:
 

--- a/django_app/redbox_app/redbox_core/middleware.py
+++ b/django_app/redbox_app/redbox_core/middleware.py
@@ -1,0 +1,22 @@
+from asgiref.sync import iscoroutinefunction
+from django.http import HttpRequest, HttpResponse
+from django.utils.decorators import sync_and_async_middleware
+
+
+@sync_and_async_middleware
+def nocache_middleware(get_response):
+    if iscoroutinefunction(get_response):
+
+        async def middleware(request: HttpRequest) -> HttpResponse:
+            response = await get_response(request)
+            response["Cache-Control"] = "no-store"
+            return response
+
+    else:
+
+        def middleware(request: HttpRequest) -> HttpResponse:
+            response = get_response(request)
+            response["Cache-Control"] = "no-store"
+            return response
+
+    return middleware

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -75,6 +75,7 @@ MIDDLEWARE = [
     "django_permissions_policy.PermissionsPolicyMiddleware",
     "csp.middleware.CSPMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "redbox_app.redbox_core.middleware.nocache_middleware",
 ]
 
 ROOT_URLCONF = "redbox_app.urls"

--- a/django_app/tests/views/test_misc_views.py
+++ b/django_app/tests/views/test_misc_views.py
@@ -14,3 +14,4 @@ def test_declaration_view_get(peter_rabbit: User, client: Client):
     client.force_login(peter_rabbit)
     response = client.get("/")
     assert response.status_code == HTTPStatus.OK, response.status_code
+    assert response["Cache-control"] == "no-store"


### PR DESCRIPTION
## Context

https://technologyprogramme.atlassian.net/browse/REDBOX-561

## Changes proposed in this pull request

Add Cache-control: no-store header to all responses.

(Whitenoise is taking care of static content, so no changes needed there.)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
