### PR TITLE
Allow user to override auto-scrolling

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -1,6 +1,11 @@
 // @ts-check
 
 class ChatMessage extends HTMLElement {
+  constructor() {
+    super();
+    this.programmaticScroll = false;
+  }
+
   connectedCallback() {
     const uuid = crypto.randomUUID();
     this.innerHTML = `
@@ -42,6 +47,7 @@ class ChatMessage extends HTMLElement {
         `;
 
     // ensure new chat-messages aren't hidden behind the chat-input
+    this.programmaticScroll = true;
     this.scrollIntoView({ block: "end" });
 
     // Insert route_display HTML
@@ -67,6 +73,15 @@ class ChatMessage extends HTMLElement {
     endPoint,
     chatControllerRef
   ) => {
+    let userScrollOverride = false;
+    window.addEventListener("scroll", (evt) => {
+      if (this.programmaticScroll) {
+        this.programmaticScroll = false;
+        return;
+      }
+      userScrollOverride = true;
+    });
+
     let responseContainer = /** @type MarkdownConverter */ (
       this.querySelector("markdown-converter")
     );
@@ -176,7 +191,10 @@ class ChatMessage extends HTMLElement {
       }
 
       // ensure new content isn't hidden behind the chat-input
-      this.scrollIntoView({ block: "end" });
+      if (!userScrollOverride) {
+        this.programmaticScroll = true;
+        this.scrollIntoView({ block: "end" });
+      }
     };
   };
 }


### PR DESCRIPTION
## Context

When a new message streams, the latest chunk is automatically scrolled into view (to prevent it from being hidden behind the sticky message-input). Feedback has shown users want to control their own scrolling behaviour rather than having to wait for streaming to finish.


## Changes proposed in this pull request

* Detect if a user has scrolled during streaming
* If so, stop the auto-scrolling


## Guidance to review

Test a few messages. Both with and without scrolling. Is the behaviour what you would expect?


## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
