### PR TITLE
Skipping demographics page should go to chats page.

### DIFF
--- a/django_app/redbox_app/templates/demographics.html
+++ b/django_app/redbox_app/templates/demographics.html
@@ -72,7 +72,7 @@
     
       <div class="govuk-button-group">
         {{ govukButton(text="Update") }}
-        {{ govukButton(text="Skip", href=url('documents'), classes="govuk-button--secondary") }}
+        {{ govukButton(text="Skip", href=url('chats'), classes="govuk-button--secondary") }}
       </div>
     </form>
 


### PR DESCRIPTION
## Context

Saving demographics changes, or bypassing the page altogether because you've already populated you data, but take you to the chats page. Skipping should do the same for consistency.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
