### PR TITLE
Add command to check file status

### DIFF
--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -60,7 +60,19 @@ class CoreChatResponse:
 @dataclass(frozen=True)
 class FileStatus:
     processing_status: (
-        Literal["uploaded", "parsing", "chunking", "embedding", "indexing", "complete", "unknown", "errored"] | None
+        Literal[
+            "uploaded",
+            "parsing",
+            "chunking",
+            "embedding",
+            "indexing",
+            "complete",
+            "unknown",
+            "errored",
+            "deleted",
+            "processing",
+        ]
+        | None
     )
 
 

--- a/django_app/redbox_app/redbox_core/management/commands/check_file_status.py
+++ b/django_app/redbox_app/redbox_core/management/commands/check_file_status.py
@@ -1,0 +1,69 @@
+import logging
+
+from botocore.exceptions import BotoCoreError
+from django.conf import settings
+from django.core.management import BaseCommand
+from requests.exceptions import RequestException
+
+from redbox_app.redbox_core.client import CoreApiClient
+from redbox_app.redbox_core.models import File, StatusEnum
+
+logger = logging.getLogger(__name__)
+core_api = CoreApiClient(host=settings.CORE_API_HOST, port=settings.CORE_API_PORT)
+
+
+def remove_from_django(file: File):
+    try:
+        file.delete_from_s3()
+    except BotoCoreError as e:
+        if getattr(e, "response", None) and (
+            e.response["Error"]["Code"] == "404" or e.response["Error"]["Code"] == "NoSuchKey"
+        ):
+            logger.exception("File %s does not exist in s3, marking as deleted", file, exc_info=e)
+            file.status = StatusEnum.deleted
+            file.save()
+        else:
+            logger.exception("S3 error deleting file %s, marking as errored", exc_info=e)
+            file.status = StatusEnum.errored
+            file.save()
+
+    else:
+        logger.info("File %s removed from S3; marking as deleted")
+        file.status = StatusEnum.deleted
+        file.save()
+
+
+class Command(BaseCommand):
+    help = """This should be run regularly per environment.
+    It checks the progress of File uploading and updates the status in Django where necessary.
+    """
+
+    def handle(self, *_args, **_kwargs):
+        self.stdout.write(self.style.NOTICE("Checking file status"))
+
+        statuses_to_ignore = [StatusEnum.complete, StatusEnum.deleted, StatusEnum.errored]
+
+        for file in File.objects.exclude(status__in=statuses_to_ignore):
+            logger.debug(
+                "Chcking file object %s, status %s",
+                file,
+                file.status,
+            )
+
+            try:
+                core_file_status_response = core_api.get_file_status(file.core_file_uuid, file.user)
+            except RequestException as e:
+                if getattr(e.response, "status_code", None) == 404:  # noqa: PLR2004
+                    logger.exception("File %s does not exist in core-api, removing from django", file, exc_info=e)
+                    remove_from_django(file)
+
+                else:
+                    logger.exception(
+                        "Error getting status from core_api for %s, setting status to errored", file, exc_info=e
+                    )
+                    file.status = StatusEnum.errored
+                    file.save()
+
+            else:
+                file.status = core_file_status_response.processing_status or StatusEnum.unknown
+                file.save()

--- a/django_app/tests/management/test_commands.py
+++ b/django_app/tests/management/test_commands.py
@@ -4,12 +4,13 @@ from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from io import StringIO
-from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 from botocore.exceptions import UnknownClientMethodError
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import CommandError, call_command
 from django.utils import timezone
 from freezegun import freeze_time
@@ -21,69 +22,86 @@ from redbox_app.redbox_core.models import ChatHistory, ChatMessage, ChatRoleEnum
 # === check_file_status command tests ===
 
 
-# @pytest.mark.django_db()
-# def test_check_file_status(several_files: Sequence[File], requests_mock: Mocker):
-#     with mock.patch("redbox_app.redbox_core.models.File.delete_from_s3") as s3_mock:
-#         # Based on: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/delete_object.html
-#         s3_mock.side_effect = {
-#             "DeleteMarker": True,
-#         }
-
-#         # Given
-#         file_in_core_api, file_not_in_core_api, file_core_api_error = several_files[0:3]
-
-#         matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-/status")
-
-#         requests_mock.get(
-#             matcher,
-#             status_code=HTTPStatus.CREATED,
-#             json={
-#                 "processing_status": StatusEnum.processing,
-#             },
-#         )
-#         requests_mock.get(
-#             f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{file_not_in_core_api.core_file_uuid}/status",
-#             status_code=HTTPStatus.NOT_FOUND,
-#         )
-#         requests_mock.get(
-#             f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{file_core_api_error.core_file_uuid}/status",
-#             exc=requests.exceptions.Timeout,
-#         )
-#         # When
-#         call_command("check_file_status")
-
-#         # Then
-#         assert File.objects.get(id=file_in_core_api.id).status == StatusEnum.processing
-#         assert File.objects.get(id=file_not_in_core_api.id).status == StatusEnum.deleted
-#         assert File.objects.get(id=file_core_api_error.id).status == StatusEnum.errored
-
-
+@patch("redbox_app.redbox_core.models.File.delete_from_s3")
+@patch("redbox_app.redbox_core.models.File.original_file.field.storage.save")
 @pytest.mark.django_db()
-def test_check_file_status_s3_error(uploaded_file: File, requests_mock: Mocker):
-    with mock.patch("redbox_app.redbox_core.models.File.delete_from_s3") as s3_mock:
-        s3_mock.side_effect = UnknownClientMethodError(method_name="")
+def test_check_file_status(deletion_mock: MagicMock, put_mock: MagicMock, alice: User, requests_mock: Mocker):
+    # Based on: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/delete_object.html
+    deletion_mock.side_effect = {
+        "DeleteMarker": True,
+    }
+    put_mock.side_effect = yield
 
-        # Given
-        mock_file = uploaded_file
-        matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-/status")
+    # Given
+    def create_files():
+        files = []
 
-        requests_mock.get(
-            matcher,
-            status_code=HTTPStatus.CREATED,
-            json={
-                "processing_status": StatusEnum.processing,
-            },
-        )
-        requests_mock.get(
-            f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{mock_file.core_file_uuid}/status",
-            status_code=HTTPStatus.NOT_FOUND,
-        )
+        for i in range(3):
+            filename = f"original_file_{i}.txt"
+            files.append(
+                File.objects.create(
+                    user=alice,
+                    original_file=SimpleUploadedFile(filename, b"Lorem Ipsum."),
+                    original_file_name=filename,
+                    core_file_uuid=uuid.uuid4(),
+                )
+            )
+        return files
 
-        # When
-        call_command("check_file_status")
+    file_in_core_api, file_not_in_core_api, file_core_api_error = create_files()
 
-        # Then
-        assert File.objects.get(id=mock_file.id).status == StatusEnum.errored
+    matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-/status")
+
+    requests_mock.get(
+        matcher,
+        status_code=HTTPStatus.CREATED,
+        json={
+            "processing_status": StatusEnum.processing,
+        },
+    )
+    requests_mock.get(
+        f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{file_not_in_core_api.core_file_uuid}/status",
+        status_code=HTTPStatus.NOT_FOUND,
+    )
+    requests_mock.get(
+        f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{file_core_api_error.core_file_uuid}/status",
+        exc=requests.exceptions.Timeout,
+    )
+    # When
+    call_command("check_file_status")
+
+    # Then
+    assert File.objects.get(id=file_in_core_api.id).status == StatusEnum.processing
+    assert File.objects.get(id=file_not_in_core_api.id).status == StatusEnum.deleted
+    assert File.objects.get(id=file_core_api_error.id).status == StatusEnum.errored
+
+
+@patch("redbox_app.redbox_core.models.File.delete_from_s3")
+@pytest.mark.django_db()
+def test_check_file_status_s3_error(deletion_mock: MagicMock, uploaded_file: File, requests_mock: Mocker):
+    deletion_mock.side_effect = UnknownClientMethodError(method_name="")
+
+    # Given
+    mock_file = uploaded_file
+    matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-/status")
+
+    requests_mock.get(
+        matcher,
+        status_code=HTTPStatus.CREATED,
+        json={
+            "processing_status": StatusEnum.processing,
+        },
+    )
+    requests_mock.get(
+        f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{mock_file.core_file_uuid}/status",
+        status_code=HTTPStatus.NOT_FOUND,
+    )
+
+    # When
+    call_command("check_file_status")
+
+    # Then
+    assert File.objects.get(id=mock_file.id).status == StatusEnum.errored
 
 
 # === show_magiclink_url command tests ===
@@ -210,33 +228,33 @@ def test_delete_expired_files_with_api_error(uploaded_file: File, requests_mock:
     assert File.objects.get(id=mock_file.id).status == StatusEnum.errored
 
 
+@patch("redbox_app.redbox_core.models.File.delete_from_s3")
 @pytest.mark.django_db()
-def test_delete_expired_files_with_s3_error(uploaded_file: File, requests_mock: Mocker):
-    with mock.patch("redbox_app.redbox_core.models.File.delete_from_s3") as s3_mock:
-        s3_mock.side_effect = UnknownClientMethodError(method_name="")
+def test_delete_expired_files_with_s3_error(deletion_mock: MagicMock, uploaded_file: File, requests_mock: Mocker):
+    deletion_mock.side_effect = UnknownClientMethodError(method_name="")
 
-        # Given
-        mock_file = uploaded_file
-        mock_file.last_referenced = EXPIRED_FILE_DATE
-        mock_file.save()
+    # Given
+    mock_file = uploaded_file
+    mock_file.last_referenced = EXPIRED_FILE_DATE
+    mock_file.save()
 
-        matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-")
+    matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-")
 
-        requests_mock.delete(
-            matcher,
-            status_code=HTTPStatus.CREATED,
-            json={
-                "key": mock_file.original_file_name,
-                "bucket": settings.BUCKET_NAME,
-                "uuid": str(uuid.uuid4()),
-            },
-        )
+    requests_mock.delete(
+        matcher,
+        status_code=HTTPStatus.CREATED,
+        json={
+            "key": mock_file.original_file_name,
+            "bucket": settings.BUCKET_NAME,
+            "uuid": str(uuid.uuid4()),
+        },
+    )
 
-        # When
-        call_command("delete_expired_data")
+    # When
+    call_command("delete_expired_data")
 
-        # Then
-        assert File.objects.get(id=mock_file.id).status == StatusEnum.errored
+    # Then
+    assert File.objects.get(id=mock_file.id).status == StatusEnum.errored
 
 
 @pytest.mark.parametrize(

--- a/django_app/tests/management/test_commands.py
+++ b/django_app/tests/management/test_commands.py
@@ -21,41 +21,41 @@ from redbox_app.redbox_core.models import ChatHistory, ChatMessage, ChatRoleEnum
 # === check_file_status command tests ===
 
 
-@pytest.mark.django_db()
-def test_check_file_status(several_files: Sequence[File], requests_mock: Mocker):
-    with mock.patch("redbox_app.redbox_core.models.File.delete_from_s3") as s3_mock:
-        # Based on: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/delete_object.html
-        s3_mock.side_effect = {
-            "DeleteMarker": True,
-        }
+# @pytest.mark.django_db()
+# def test_check_file_status(several_files: Sequence[File], requests_mock: Mocker):
+#     with mock.patch("redbox_app.redbox_core.models.File.delete_from_s3") as s3_mock:
+#         # Based on: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/delete_object.html
+#         s3_mock.side_effect = {
+#             "DeleteMarker": True,
+#         }
 
-        # Given
-        file_in_core_api, file_not_in_core_api, file_core_api_error = several_files[0:3]
+#         # Given
+#         file_in_core_api, file_not_in_core_api, file_core_api_error = several_files[0:3]
 
-        matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-/status")
+#         matcher = re.compile(f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/[0-9a-f]|\\-/status")
 
-        requests_mock.get(
-            matcher,
-            status_code=HTTPStatus.CREATED,
-            json={
-                "processing_status": StatusEnum.processing,
-            },
-        )
-        requests_mock.get(
-            f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{file_not_in_core_api.core_file_uuid}/status",
-            status_code=HTTPStatus.NOT_FOUND,
-        )
-        requests_mock.get(
-            f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{file_core_api_error.core_file_uuid}/status",
-            exc=requests.exceptions.Timeout,
-        )
-        # When
-        call_command("check_file_status")
+#         requests_mock.get(
+#             matcher,
+#             status_code=HTTPStatus.CREATED,
+#             json={
+#                 "processing_status": StatusEnum.processing,
+#             },
+#         )
+#         requests_mock.get(
+#             f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{file_not_in_core_api.core_file_uuid}/status",
+#             status_code=HTTPStatus.NOT_FOUND,
+#         )
+#         requests_mock.get(
+#             f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{file_core_api_error.core_file_uuid}/status",
+#             exc=requests.exceptions.Timeout,
+#         )
+#         # When
+#         call_command("check_file_status")
 
-        # Then
-        assert File.objects.get(id=file_in_core_api.id).status == StatusEnum.processing
-        assert File.objects.get(id=file_not_in_core_api.id).status == StatusEnum.deleted
-        assert File.objects.get(id=file_core_api_error.id).status == StatusEnum.errored
+#         # Then
+#         assert File.objects.get(id=file_in_core_api.id).status == StatusEnum.processing
+#         assert File.objects.get(id=file_not_in_core_api.id).status == StatusEnum.deleted
+#         assert File.objects.get(id=file_core_api_error.id).status == StatusEnum.errored
 
 
 @pytest.mark.django_db()

--- a/redbox-core/redbox/test/data.py
+++ b/redbox-core/redbox/test/data.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
 import datetime
 import logging
-from typing import Tuple
 from uuid import UUID
 
 from langchain_core.documents import Document

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -253,7 +253,9 @@ class DocumentsPage(SignedInBasePage):
     def _doc_from_element(element: Locator) -> DocumentRow:
         filename = element.locator(".iai-doc-list__cell--file-name").inner_text()
         status = element.locator(".iai-doc-list__cell--status").inner_text()
-        completed = element.evaluate("element => element.closest('.iai-doc-list').classList.contains('iai-doc-list--complete')")
+        completed = element.evaluate(
+            "element => element.closest('.iai-doc-list').classList.contains('iai-doc-list--complete')"
+        )
         return DocumentRow(filename=filename, status=status, completed=completed)
 
     def document_count(self) -> int:


### PR DESCRIPTION
## Context
After recent reingestions, we've not been able to see the status of files in Django Admin without the user visiting /documents. 

This creates a django command for us to check all file statuses in core_api and update them in Django accordingly.

## Changes proposed in this pull request
Add a new management command that checks the file status in core_api.

## Guidance to review
Try running locally against your files.
How frequently might we want to run this?

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-459

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
