### PR TITLE
Tighten CSP around trusted types

### DIFF
--- a/django_app/frontend/src/js/trusted-types.js
+++ b/django_app/frontend/src/js/trusted-types.js
@@ -15,7 +15,6 @@ if (typeof window.trustedTypes !== "undefined") {
             tagName === "sources-list" ||
             tagName === "tool-tip" ||
             tagName === "feedback-buttons" ||
-            tagName === "chat-title" ||
             tagName === "copy-text",
           attributeNameCheck: (attr) => true,
           allowCustomizedBuiltInElements: true,

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -162,6 +162,7 @@ CSP_SCRIPT_SRC = (
 CSP_OBJECT_SRC = ("'none'",)
 CSP_REQUIRE_TRUSTED_TYPES_FOR = ("'script'",)
 CSP_TRUSTED_TYPES = ("dompurify", "default")
+CSP_REPORT_TO = "csp-endpoint"
 CSP_FONT_SRC = (
     "'self'",
     "s3.amazonaws.com",

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -161,6 +161,7 @@ CSP_SCRIPT_SRC = (
 )
 CSP_OBJECT_SRC = ("'none'",)
 CSP_REQUIRE_TRUSTED_TYPES_FOR = ("'script'",)
+CSP_TRUSTED_TYPES = ("dompurify", "default")
 CSP_FONT_SRC = (
     "'self'",
     "s3.amazonaws.com",

--- a/django_app/redbox_app/templates/citations.html
+++ b/django_app/redbox_app/templates/citations.html
@@ -19,6 +19,6 @@
 </div>
 
 <script src="{{ static('js/libs/showdown.min.js') }}"></script>
-<script src="{{ static('js/citations.js') }}"></script>
+<script type="module" src="{{ static('js/citations.js') }}" ></script>
 
 {% endblock %}


### PR DESCRIPTION
## Context

Improvements to our Content Security Policy following the pen-testing report.


## Changes proposed in this pull request

* Add a `trusted-types` directive - this prevents the creation of trusted-type policies other than what we have specified
* A small tidy-up our default trusted-types policy
* Linking in our CSP to our new `report-to` header
* Fixing a minor console error on the citations page I saw while testing


## Guidance to review

* Check the code looks sensible
* Check everything still works fine


## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-558?atlOrigin=eyJpIjoiY2QyN2Q3MjhiYTcxNGJhZmJjZGFlMzg1MmI3MmI0MWEiLCJwIjoiaiJ9


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
