### PR TITLE
Ensure footer is pinned to bottom on larger screens

### DIFF
--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -1,5 +1,5 @@
 main:has(.iai-chat-input),
-body:has(.iai-environment-warning) main {
+body:has(.iai-environment-warning) main:has(.iai-chat-input) {
   min-height: 0;
 }
 @media (min-width: 641px) {


### PR DESCRIPTION
## Context

Footer not pinned to bottom on large screens:

![image](https://github.com/user-attachments/assets/58791d3d-25f9-4791-be3e-65644dd33a7c)


## Changes proposed in this pull request

* Fix dodgy CSS selector
