### PR TITLE
Remove info route from integration test

### DIFF
--- a/tests/test_journey.py
+++ b/tests/test_journey.py
@@ -98,7 +98,6 @@ def test_user_journey(page: Page, email_address: str):
         ("chat", True, False),
         ("search", False, True),
         ("search", True, True),
-        ("info", False, False),
     ]:
         question = f"@{route} What do I need to install?"
         logger.info("Asking %r", question)


### PR DESCRIPTION
## Context
Our integration tests are failing because the info route  is mentioned, and this no longer exists. 

## Changes proposed in this pull request
Remove the info route from the integration test. 

## Guidance to review
Does this pass? https://github.com/i-dot-ai/redbox/actions/runs/10193774593 

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
