### PR TITLE
Fix weird issue with preprod release not having the users github handle

### DIFF
--- a/.github/workflows/_cicd.yml
+++ b/.github/workflows/_cicd.yml
@@ -41,7 +41,7 @@ jobs:
       environment: preprod
       core_infra_repo_reference: 'refs/heads/main'
       config_repo_reference: 'refs/heads/main'
-      author_name: ${{ github.event.pull_request.user.login }}
+      author_name: ${{ github.actor }}
     secrets: inherit
 
   release-prod:


### PR DESCRIPTION
## Context

Releases to preprod for some reason don't have the users github handle anymore

## Changes proposed in this pull request

- Attempt to replace the reference to the github handle with the same one we use for dev

## Guidance to review

Merge and allow automated run to pull in the name

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
