### PR TITLE
Add comment explaining why poetry-plugin-bundle is pinned

### DIFF
--- a/django_app/Dockerfile
+++ b/django_app/Dockerfile
@@ -17,6 +17,7 @@ FROM python:3.12-slim AS poetry-packages
 
 RUN apt-get update && apt-get install --yes build-essential > /dev/null
 
+# TODO: Unpin poetry-plugin-bundle when https://github.com/python-poetry/poetry-plugin-bundle/issues/112 is fixed.
 RUN pip install poetry poetry-plugin-bundle==1.3.0
 
 WORKDIR /src


### PR DESCRIPTION
## Context

Add comment explaining that poetry-plugin-bundle is pinned until https://github.com/python-poetry/poetry-plugin-bundle/issues/112 is fixed.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
