### PR TITLE
Setting embedding batch size. Fixing some vscode env nonsense too

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -49,6 +49,7 @@ AWS_ACCESS_KEY=minioadmin
 AWS_SECRET_KEY=minioadmin
 
 # minio or s3
+OBJECT_STORE=moto
 BUCKET_NAME=redbox-storage-dev
 
 # === Django App ===

--- a/.env.test
+++ b/.env.test
@@ -49,7 +49,6 @@ AWS_ACCESS_KEY=minioadmin
 AWS_SECRET_KEY=minioadmin
 
 # minio or s3
-OBJECT_STORE=moto
 BUCKET_NAME=redbox-storage-dev
 
 # === Django App ===

--- a/.vscode/redbox.code-workspace
+++ b/.vscode/redbox.code-workspace
@@ -29,7 +29,4 @@
 			"path": ".."
 		}
 	],
-	"settings": {
-		"python.envFile": "${workspaceFolder}/../.env"
-	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,4 +7,5 @@
         "editor.defaultFormatter": "ms-python.black-formatter"
     },
     "python.analysis.autoImportCompletions": true,
+    "python.experiments.optOutFrom": ["pythonTerminalEnvVarActivation"]
 }

--- a/core-api/.vscode/settings.json
+++ b/core-api/.vscode/settings.json
@@ -13,5 +13,5 @@
         ".",
         "-m not ( ai )"
     ],
-    "python.testing.pytestPath": "venv/bin/python -m pytest"
+    "python.testing.pytestPath": "venv/bin/python -m pytest",
 }

--- a/redbox-core/redbox/embeddings/langchain.py
+++ b/redbox-core/redbox/embeddings/langchain.py
@@ -12,6 +12,7 @@ def get_azure_embeddings(env: Settings):
         max_retries=env.embedding_max_retries,
         retry_min_seconds=env.embedding_retry_min_seconds,
         retry_max_seconds=env.embedding_retry_max_seconds,
+        chunk_size=env.embedding_max_batch_size
     )
 
 

--- a/redbox-core/redbox/embeddings/langchain.py
+++ b/redbox-core/redbox/embeddings/langchain.py
@@ -12,7 +12,7 @@ def get_azure_embeddings(env: Settings):
         max_retries=env.embedding_max_retries,
         retry_min_seconds=env.embedding_retry_min_seconds,
         retry_max_seconds=env.embedding_retry_max_seconds,
-        chunk_size=env.embedding_max_batch_size
+        chunk_size=env.embedding_max_batch_size,
     )
 
 

--- a/redbox-core/tests/conftest.py
+++ b/redbox-core/tests/conftest.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from botocore.exceptions import ClientError
 from elasticsearch import Elasticsearch
 
 from redbox.models import Chunk, File, Settings
@@ -48,6 +47,7 @@ def file_belonging_to_alice(file_pdf_path, alice, env) -> File:
         creator_user_uuid=alice,
     )
 
+
 @pytest.fixture()
 def file_belonging_to_bob(file_pdf_path, bob, env) -> File:
     return File(
@@ -55,6 +55,7 @@ def file_belonging_to_bob(file_pdf_path, bob, env) -> File:
         bucket=env.bucket_name,
         creator_user_uuid=bob,
     )
+
 
 @pytest.fixture()
 def chunk_belonging_to_alice(file_belonging_to_alice) -> Chunk:
@@ -64,6 +65,7 @@ def chunk_belonging_to_alice(file_belonging_to_alice) -> Chunk:
         index=1,
         text="hello, i am Alice!",
     )
+
 
 @pytest.fixture()
 def chunk_belonging_to_bob(file_belonging_to_bob) -> Chunk:
@@ -84,9 +86,11 @@ def chunk_belonging_to_claire(claire) -> Chunk:
         text="hello, i am Claire!",
     )
 
+
 @pytest.fixture
 def file_pdf_path() -> Path:
     return Path(__file__).parents[2] / "tests" / "data" / "pdf" / "Cabinet Office - Wikipedia.pdf"
+
 
 @pytest.fixture()
 def stored_chunk_belonging_to_alice(elasticsearch_storage_handler, chunk_belonging_to_alice) -> Chunk:


### PR DESCRIPTION
## Context

We hit rate limiting on large files due to embedding too fast.

## Changes proposed in this pull request

Set the embedding batch size on Azure Embeddings object (missed in previous work). This should drop the rate at which we're consuming our rate limit and smooth things out for large files where there are a large number of documents queued up

## Guidance to review

The vscode stuff is separate but bothering me locally and broke testing

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
