### PR TITLE
Bugfix/ai settings type validation

### DIFF
--- a/redbox-core/redbox/chains/graph.py
+++ b/redbox-core/redbox/chains/graph.py
@@ -61,13 +61,25 @@ def make_chat_prompt_from_messages_runnable(tokeniser: Encoding, llm_max_tokens:
         Create a ChatPromptTemplate as part of a chain using 'chat_history'.
         Returns the PromptValue using values in the input_dict
         """
+        if state["route_name"] == ChatRoute.chat:
+            system_prompt = state["query"].ai_settings.chat_system_prompt
+            question_prompt = state["query"].ai_settings.chat_question_prompt
+        elif state["route_name"] == ChatRoute.chat_with_docs:
+            system_prompt = state["query"].ai_settings.chat_with_docs_system_prompt
+            question_prompt = state["query"].ai_settings.chat_with_docs_question_prompt
+        elif state["route_name"] == ChatRoute.chat_with_docs_map_reduce:
+            system_prompt = state["query"].ai_settings.chat_map_system_prompt
+            question_prompt = state["query"].ai_settings.chat_map_question_prompt
+        elif state["route_name"] == ChatRoute.search:
+            system_prompt = state["query"].ai_settings.retrieval_system_prompt
+            question_prompt = state["query"].ai_settings.retrieval_question_prompt
+
         log.debug("Setting chat prompt")
-        system_prompt_message = [("system", state["query"].ai_settings.chat_system_prompt)]
-        prompts_budget = len(tokeniser.encode(state["query"].ai_settings.chat_system_prompt)) - len(
-            tokeniser.encode(state["query"].ai_settings.chat_question_prompt)
+        system_prompt_message = [("system", system_prompt)]
+        prompts_budget = len(tokeniser.encode(system_prompt)) + len(
+            tokeniser.encode(question_prompt)
         )
-        token_budget = state["query"].ai_settings.context_window_size - llm_max_tokens - prompts_budget
-        chat_history_budget = token_budget - len(tokeniser.encode(state["query"].question))
+        chat_history_budget = state["query"].ai_settings.context_window_size - llm_max_tokens - prompts_budget
 
         if chat_history_budget <= 0:
             raise QuestionLengthError
@@ -83,10 +95,12 @@ def make_chat_prompt_from_messages_runnable(tokeniser: Encoding, llm_max_tokens:
         return ChatPromptTemplate.from_messages(
             system_prompt_message
             + [(msg["role"], msg["text"]) for msg in truncated_history]
-            + [("user", state["query"].ai_settings.chat_question_prompt)]
-        ).invoke(state["query"].dict() | state.get("prompt_args", {}))
+            + [("user", question_prompt)]
+        ).invoke(state["query"].model_dump() | state.get("prompt_args", {}))
 
     return chat_prompt_from_messages
+
+
 
 
 @chain

--- a/redbox-core/redbox/chains/graph.py
+++ b/redbox-core/redbox/chains/graph.py
@@ -76,9 +76,7 @@ def make_chat_prompt_from_messages_runnable(tokeniser: Encoding, llm_max_tokens:
 
         log.debug("Setting chat prompt")
         system_prompt_message = [("system", system_prompt)]
-        prompts_budget = len(tokeniser.encode(system_prompt)) + len(
-            tokeniser.encode(question_prompt)
-        )
+        prompts_budget = len(tokeniser.encode(system_prompt)) + len(tokeniser.encode(question_prompt))
         chat_history_budget = state["query"].ai_settings.context_window_size - llm_max_tokens - prompts_budget
 
         if chat_history_budget <= 0:
@@ -99,8 +97,6 @@ def make_chat_prompt_from_messages_runnable(tokeniser: Encoding, llm_max_tokens:
         ).invoke(state["query"].model_dump() | state.get("prompt_args", {}))
 
     return chat_prompt_from_messages
-
-
 
 
 @chain

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -44,17 +44,7 @@ RETRIEVAL_SYSTEM_PROMPT = (
     "If dealing dealing with lots of data return it in markdown table format. "
 )
 
-SUMMARISATION_SYSTEM_PROMPT = (
-    "You are an AI assistant tasked with summarizing documents. "
-    "Your goal is to extract the most important information and present it in "
-    "a concise and coherent manner. Please follow these guidelines while summarizing: \n"
-    "1) Identify and highlight key points,\n"
-    "2) Avoid repetition,\n"
-    "3) Ensure the summary is easy to understand,\n"
-    "4) Maintain the original context and meaning.\n"
-)
-
-MAP_SYSTEM_PROMPT = (
+CHAT_MAP_SYSTEM_PROMPT = (
     "You are an AI assistant tasked with summarizing documents. "
     "Your goal is to extract the most important information and present it in "
     "a concise and coherent manner. Please follow these guidelines while summarizing: \n"
@@ -88,16 +78,9 @@ CHAT_QUESTION_PROMPT = "{question}\n=========\n Response: "
 
 CHAT_WITH_DOCS_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {formatted_documents} \n\n Answer: "
 
-CHAT_WITH_DOCS_REDUCE_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {summaries} \n\n Answer: "
-
 RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
 
-SUMMARISATION_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
-
 CHAT_MAP_QUESTION_PROMPT = "Question: {question}. \n Documents: \n {formatted_documents} \n\n Answer: "
-
-
-REDUCE_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {formatted_documents} \n\n Answer: "
 
 CONDENSE_QUESTION_PROMPT = "{question}\n=========\n Standalone question: "
 
@@ -116,18 +99,14 @@ class AISettings(BaseModel):
     chat_with_docs_system_prompt: str = CHAT_WITH_DOCS_SYSTEM_PROMPT
     chat_with_docs_question_prompt: str = CHAT_WITH_DOCS_QUESTION_PROMPT
     chat_with_docs_reduce_system_prompt: str = CHAT_WITH_DOCS_REDUCE_SYSTEM_PROMPT
-    chat_with_docs_reduce_question_prompt: str = CHAT_WITH_DOCS_REDUCE_QUESTION_PROMPT
     retrieval_system_prompt: str = RETRIEVAL_SYSTEM_PROMPT
     retrieval_question_prompt: str = RETRIEVAL_QUESTION_PROMPT
     condense_system_prompt: str = CONDENSE_SYSTEM_PROMPT
     condense_question_prompt: str = CONDENSE_QUESTION_PROMPT
-    summarisation_system_prompt: str = SUMMARISATION_SYSTEM_PROMPT
-    summarisation_question_prompt: str = SUMMARISATION_QUESTION_PROMPT
     map_max_concurrency: int = 128
-    map_system_prompt: str = MAP_SYSTEM_PROMPT
+    chat_map_system_prompt: str = CHAT_MAP_SYSTEM_PROMPT
     chat_map_question_prompt: str = CHAT_MAP_QUESTION_PROMPT
     reduce_system_prompt: str = REDUCE_SYSTEM_PROMPT
-    reduce_question_prompt: str = REDUCE_QUESTION_PROMPT
     llm_max_tokens: int = 1024
 
     # size: int = 19 rag_k

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -9,7 +9,7 @@ from typing import TypedDict, Literal, Annotated, Required, NotRequired
 from uuid import UUID
 from operator import add
 
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 from langchain_core.documents import Document
 
 
@@ -135,10 +135,6 @@ class AISettings(BaseModel):
     # num_candidates: int = 13 rag_num_candidates
     knn_boost: int = 1
     similarity_threshold: int = 0
-
-    @property
-    def stuff_chunk_max_tokens(self) -> int:
-        return int(self.context_window_size * self.stuff_chunk_context_ratio)
 
 
 class ChainInput(BaseModel):


### PR DESCRIPTION
## Context

We get validation errors when trying to set AISettings in a request to core-api.
All responses use the chat prompts so we never use documents.

## Changes proposed in this pull request

Drop all use of the pydantic v1 classes (models/chain.py) so we're just using pydantic v2 and all is well
Added a switch in the chat_prompt template creation runnable to check what the route is and choose the prompts accordingly. This is pretty ugly and will be improved I'm sure but it fixes the bug for now

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
