### PR TITLE
Fix incorrect name for target modules that missed core-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,9 @@ DOCKER_SERVICES=$$(docker compose config --services | grep -v mlflow)
 AUTO_APPLY_RESOURCES = module.django-app.aws_ecs_task_definition.aws-ecs-task \
                        module.django-app.aws_ecs_service.aws-ecs-service \
                        module.django-app.data.aws_ecs_task_definition.main \
-                       module.core-api.aws_ecs_task_definition.aws-ecs-task \
-                       module.core-api.aws_ecs_service.aws-ecs-service \
-                       module.core-api.data.aws_ecs_task_definition.main \
+                       module.core_api.aws_ecs_task_definition.aws-ecs-task \
+                       module.core_api.aws_ecs_service.aws-ecs-service \
+                       module.core_api.data.aws_ecs_task_definition.main \
                        module.worker.aws_ecs_task_definition.aws-ecs-task \
                        module.worker.aws_ecs_service.aws-ecs-service \
                        module.worker.data.aws_ecs_task_definition.main \


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
