### PR TITLE
Feature/ecs ready check and lambda image change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,8 @@ AUTO_APPLY_RESOURCES = module.django-app.aws_ecs_task_definition.aws-ecs-task \
                        module.worker.data.aws_ecs_task_definition.main \
                        aws_secretsmanager_secret.django-app-secret \
                        aws_secretsmanager_secret.worker-secret \
-                       aws_secretsmanager_secret.core-api-secret
+                       aws_secretsmanager_secret.core-api-secret \
+                       module.django-lambda.aws_lambda_function.lambda_function
 
 target_modules = $(foreach resource,$(AUTO_APPLY_RESOURCES),-target $(resource))
 

--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -107,6 +107,7 @@ module "django-app" {
   environment_variables        = local.django_app_environment_variables
   secrets                      = local.reconstructed_django_secrets
   auto_scale_off_peak_times    = true
+  wait_for_ready_state         = true
 }
 
 module "core_api" {
@@ -141,6 +142,7 @@ module "core_api" {
   secrets                      = local.reconstructed_core_secrets
   ephemeral_storage            = 30
   auto_scale_off_peak_times    = true
+  wait_for_ready_state         = true
 }
 
 
@@ -169,6 +171,7 @@ module "worker" {
   http_healthcheck             = false
   ephemeral_storage            = 30
   auto_scale_off_peak_times    = true
+  wait_for_ready_state         = true
 }
 
 

--- a/infrastructure/aws/lambda.tf
+++ b/infrastructure/aws/lambda.tf
@@ -8,7 +8,7 @@ module "django-lambda" {
     command = ["venv/bin/django-admin", each.value.command]
   }
   package_type                   = "Image"
-  image_uri                      = "${var.ecr_repository_uri}/${var.project_name}-django-app:${lower(var.env)}"
+  image_uri                      = "${var.ecr_repository_uri}/${var.project_name}-django-app:${var.image_tag}"
   function_name                  = "${local.name}-${each.value.task_name}-lambda"
   iam_role_name                  = "${local.name}-${each.value.task_name}-lambda-role"
   timeout                        = 600


### PR DESCRIPTION
## Context

Currently the ECS tasks can be deployed and fail to start, but we don't see that in the deployment

Also, the lambda is currently set by env tag which is always behind the current deployment which could cause migration issues

## Changes proposed in this pull request

- Add `wait_for_ready_state` to ecs tasks to wait for them to come up
- Changed lambda to use the same image version as the ecs tasks
- Update the auto_apply make command to also update the lambda image

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
