### PR TITLE
Retry if sending feedback fails

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/feedback-buttons.js
+++ b/django_app/frontend/src/js/web-components/chats/feedback-buttons.js
@@ -86,19 +86,29 @@ class FeedbackButtons extends HTMLElement {
     /**
      * Posts data back to the server
      */
-    const sendFeedback = () => {
+    const sendFeedback = async (retry = 0) => {
+      const MAX_RETRIES = 10;
+      const RETRY_INTERVAL_SECONDS = 10;
       const csrfToken =
         /** @type {HTMLInputElement | null} */ (
           document.querySelector('[name="csrfmiddlewaretoken"]')
         )?.value || "";
-      fetch(`/ratings/${messageId}/`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-CSRFToken": csrfToken,
-        },
-        body: JSON.stringify(collectedData),
-      });
+      try {
+        await fetch(`/ratings/${messageId}/`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": csrfToken,
+          },
+          body: JSON.stringify(collectedData),
+        });
+      } catch (err) {
+        if (retry < MAX_RETRIES) {
+          window.setTimeout(() => {
+            sendFeedback(retry + 1);
+          }, RETRY_INTERVAL_SECONDS * 1000);
+        }
+      }
     };
 
     /**


### PR DESCRIPTION
## Context

There was user feedback around feedback not being sent if there’s a network/VPN issue, and lack of error message.

I don’t think showing an error message is necessarily helpful in this case - at least not specific/locally to this. But we can try resending this data automatically, just to give it as much chance of being received as possible.


## Changes proposed in this pull request

* If sending feedback fails, try again in 10 seconds, up to 10 times.


## Guidance to review

* Check that the code looks sensible
* You can test by getting a response, and then disconnecting from the network, checking the requests in dev tools. If you really want to.


## Questions

* I've plucked these numbers out of thin air (10 seconds, 10 attempts). Do they sound sensible?
* Do we need a limit, or should we keep trying continuously (i.e. until successful or the page is reloaded)


## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-607


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
