### PR TITLE
Show loading message when uploading large files

### DIFF
--- a/django_app/frontend/package.json
+++ b/django_app/frontend/package.json
@@ -7,6 +7,7 @@
     "src/js/autosubmit.js",
     "src/js/chats.js",
     "src/js/citations.js",
+    "src/js/document-upload.js",
     "src/js/documents.js",
     "src/js/main.js",
     "src/js/posthog.js"

--- a/django_app/frontend/src/js/document-upload.js
+++ b/django_app/frontend/src/js/document-upload.js
@@ -1,0 +1,1 @@
+import "./web-components/documents/upload-button.js";

--- a/django_app/frontend/src/js/trusted-types.js
+++ b/django_app/frontend/src/js/trusted-types.js
@@ -11,11 +11,12 @@ if (typeof window.trustedTypes !== "undefined") {
         RETURN_TRUSTED_TYPE: false,
         CUSTOM_ELEMENT_HANDLING: {
           tagNameCheck: (tagName) =>
+            tagName === "copy-text" ||
+            tagName === "feedback-buttons" ||
+            tagName === "loading-message" ||
             tagName === "markdown-converter" ||
             tagName === "sources-list" ||
-            tagName === "tool-tip" ||
-            tagName === "feedback-buttons" ||
-            tagName === "copy-text",
+            tagName === "tool-tip",
           attributeNameCheck: (attr) => true,
           allowCustomizedBuiltInElements: true,
         },

--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import "../loading-message.js";
+
 class ChatMessage extends HTMLElement {
   constructor() {
     super();
@@ -23,14 +25,9 @@ class ChatMessage extends HTMLElement {
                 ${
                   !this.dataset.text
                     ? `
-                      <div class="rb-loading-ellipsis govuk-body-s" aria-label="Loading message">
-                        Loading
-                        <span aria-hidden="true">.</span>
-                        <span aria-hidden="true">.</span>
-                        <span aria-hidden="true">.</span>
-                      </div>
+                      <loading-message data-aria-label="Loading message"></loading-message>
                       <div class="rb-loading-complete govuk-visually-hidden" aria-live="assertive"></div>
-                      `
+                    `
                     : ""
                 }
                 <sources-list></sources-list>

--- a/django_app/frontend/src/js/web-components/documents/upload-button.js
+++ b/django_app/frontend/src/js/web-components/documents/upload-button.js
@@ -1,0 +1,18 @@
+// @ts-check
+
+import "../loading-message.js";
+
+/** So completed docs can be added to this list */
+class UploadButton extends HTMLElement {
+  connectedCallback() {
+    this.closest("form")?.addEventListener("submit", () => {
+      this.querySelector("button")?.remove();
+      let el = document.createElement("loading-message");
+      el.dataset.message = "Uploading";
+      this.appendChild(el);
+      this.setAttribute("tabindex", "-1");
+      this.focus();
+    });
+  }
+}
+customElements.define("upload-button", UploadButton);

--- a/django_app/frontend/src/js/web-components/loading-message.js
+++ b/django_app/frontend/src/js/web-components/loading-message.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+class LoadingMessage extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <div class="rb-loading-ellipsis govuk-body-s" aria-label="${
+        this.dataset.dataAriaLabel || this.dataset.message || "Loading"
+      }">
+        ${this.dataset.message || "Loading"}
+        <span aria-hidden="true">.</span>
+        <span aria-hidden="true">.</span>
+        <span aria-hidden="true">.</span>
+      </div>
+    `;
+  }
+}
+customElements.define("loading-message", LoadingMessage);

--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -112,6 +112,9 @@ body {
 .rb-file-types {
   font-size: 0.875rem;
 }
+upload-button {
+  display: block;
+}
 
 /* Citations page */
 .rb-citations {

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -9,7 +9,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
 
-  <link rel="icon" sizes="any" href="{{static("images/favicon.ico")}}" type="image/svg+xml">
+  <link rel="icon" sizes="any" href="{{static("icons/favicon.ico")}}" type="image/svg+xml">
   <link rel="manifest" href="{{static("govuk-assets/manifest.json")}}">
 
   <meta name="robots" content="noindex, nofollow">

--- a/django_app/redbox_app/templates/upload.html
+++ b/django_app/redbox_app/templates/upload.html
@@ -33,12 +33,16 @@
           <input class="govuk-file-upload {% if errors.upload_doc %} govuk-file-upload--error{% endif %}" multiple id="upload-docs" name="uploadDocs" type="file" aria-describedby="upload-docs-notification upload-docs-filetypes {% if errors.upload_doc %} file-upload-docs-error{% endif %}">
         </div>
 
-        {{ govukButton(text="Upload", prevent_double_click=True) }}
+        <upload-button>
+          {{ govukButton(text="Upload", prevent_double_click=True, classes="govuk-!-display-inline-block") }}
+        </upload-button>
 
       </form>
 
     </div>
   </div>
 </div>
+
+<script src="{{ static('js/document-upload.js') }}" type="module"></script>
 
 {% endblock %}


### PR DESCRIPTION
## Context

When uploading large files, the UI doesn’t give any feedback to show that the file is uploading. This could cause confusion and/or lead to duplicate uploads.


## Changes proposed in this pull request

* Add an uploading message (the same one as used for messages)


## Guidance to review

* Upload a large PDF (I have a 100MB one I can pass on if that's helpful)


## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-618


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
