### PR TITLE
Added unstructured host to worker vscode launch config

### DIFF
--- a/worker/.vscode/launch.json
+++ b/worker/.vscode/launch.json
@@ -20,7 +20,8 @@
             "env": {
                 "ELASTIC__HOST": "localhost",
                 "REDIS_HOST": "localhost",
-                "MINIO_HOST": "localhost"
+                "MINIO_HOST": "localhost",
+                "UNSTRUCTURED_HOST": "localhost"
             }
         }
     ]


### PR DESCRIPTION

## Context

Developers should be able to use vscode launch to start core-api and worker, currently the worker uses the wrong hostname for unstructured

## Changes proposed in this pull request

Add UNSTRUCTURED_HOST to the list of overrides in vscode launch. These are set here to avoid having to set them in .env which has the correct values for docker-compose

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
