### PR TITLE
Make chat-history and document-selection panels sticky

### DIFF
--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -24,11 +24,42 @@ body:has(.iai-environment-warning) main:has(.iai-chat-input) {
   }
 }
 @media (min-width: 1020px) {
+  body:has(.iai-chat-input) .iai-environment-warning {
+    position: fixed;
+    width: 100%;
+    z-index: 10;
+  }
+  body:has(.iai-chat-input) .iai-top-nav {
+    position: fixed;
+    width: 100%;
+    z-index: 10;
+  }
+  body:has(.iai-environment-warning) .iai-top-nav {
+    top: 26px;
+  }
+  main:has(.iai-chat-input) {
+    padding-top: 4.5rem;
+  }
+  body:has(.iai-environment-warning) main:has(.iai-chat-input) {
+    padding-top: 6.5rem;
+  }
   .govuk-grid-row:has(.iai-chat-input) {
     .govuk-grid-column-one-third,
     .govuk-grid-column-two-thirds {
       min-height: calc(100vh - 10.25rem);
     }
+  }
+  .rb-left-column-container {
+    left: 0;
+    position: sticky;
+    top: 4.5rem;
+    width: calc(100% - 30px);
+  }
+  body:has(.iai-environment-warning) .rb-left-column-container {
+    top: 6.5rem;
+  }
+  .iai-panel__scrollable {
+    max-height: calc(50vh - 12rem);
   }
 }
 

--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -24,6 +24,14 @@ body:has(.iai-environment-warning) main:has(.iai-chat-input) {
   }
 }
 @media (min-width: 1020px) {
+  .govuk-grid-row:has(.iai-chat-input) {
+    .govuk-grid-column-one-third,
+    .govuk-grid-column-two-thirds {
+      min-height: calc(100vh - 10.25rem);
+    }
+  }
+}
+@media (min-width: 1020px) and (min-height: 600px) {
   body:has(.iai-chat-input) .iai-environment-warning {
     position: fixed;
     width: 100%;
@@ -42,12 +50,6 @@ body:has(.iai-environment-warning) main:has(.iai-chat-input) {
   }
   body:has(.iai-environment-warning) main:has(.iai-chat-input) {
     padding-top: 6.5rem;
-  }
-  .govuk-grid-row:has(.iai-chat-input) {
-    .govuk-grid-column-one-third,
-    .govuk-grid-column-two-thirds {
-      min-height: calc(100vh - 10.25rem);
-    }
   }
   .rb-left-column-container {
     left: 0;

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -16,11 +16,12 @@
   <form class="govuk-grid-row js-message-input" action="/post-message/" method="post">
 
     <div class="govuk-grid-column-one-third">
+      <div class="rb-left-column-container govuk-!-margin-bottom-6">
 
-      <a class="iai-large-button" role="button" href="{{ url('chats') }}">
-        <svg width="22" height="22" fill="none" aria-hidden="true" focusable="false"><path d="M21 11c0-5.523-4.477-10-10-10S1 5.477 1 11s4.477 10 10 10 10-4.477 10-10z" stroke="currentColor" stroke-linejoin="round"/><g filter="url(#A)"><path d="M15.656 11.656h-4v4h-1.312v-4h-4v-1.312h4v-4h1.312v4h4v1.312z" fill="currentColor"/></g><defs><filter x="6" y="6" width="10" height="10" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="A"/><feColorMatrix in="SourceAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/><feOffset dx="1" dy="1"/><feColorMatrix values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/><feBlend in2="A"/><feBlend in="SourceGraphic"/></filter></defs></svg>
-        New chat
-      </a>
+        <a class="iai-large-button" role="button" href="{{ url('chats') }}">
+          <svg width="22" height="22" fill="none" aria-hidden="true" focusable="false"><path d="M21 11c0-5.523-4.477-10-10-10S1 5.477 1 11s4.477 10 10 10 10-4.477 10-10z" stroke="currentColor" stroke-linejoin="round"/><g filter="url(#A)"><path d="M15.656 11.656h-4v4h-1.312v-4h-4v-1.312h4v-4h1.312v4h4v1.312z" fill="currentColor"/></g><defs><filter x="6" y="6" width="10" height="10" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="A"/><feColorMatrix in="SourceAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/><feOffset dx="1" dy="1"/><feColorMatrix values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/><feBlend in2="A"/><feBlend in="SourceGraphic"/></filter></defs></svg>
+          New chat
+        </a>
 
       <div class="iai-panel govuk-!-margin-top-6">
         <h2 class="govuk-heading-s">Recent chats</h2>
@@ -38,32 +39,33 @@
         </div>
       </div>
 
-      <document-selector class="iai-panel iai-panel govuk-!-margin-top-6 govuk-!-margin-bottom-9">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-            <h3 class="govuk-fieldset__heading">Documents to use</h3>
-          </legend>
-          <div class="govuk-checkboxes govuk-checkboxes--small iai-panel__scrollable" data-module="govuk-checkboxes">
-            {% for file in completed_files %}
-              <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="file-{{ file.id }}" name="file-{{ file.id }}" type="checkbox" value="{{ file.id }}" {% if file.selected %}checked{% endif %}>
-                <label class="govuk-checkboxes__label govuk-body-s" for="file-{{ file.id }}">{{ file.original_file_name }}</label>
-              </div>
-            {% endfor %}
-            {# files not yet ready - stored here to be moved to main list once ready #}
-            <div hidden>
-              {% for file in processing_files %}
+        <document-selector class="iai-panel iai-panel govuk-!-margin-top-6">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              <h3 class="govuk-fieldset__heading">Documents to use</h3>
+            </legend>
+            <div class="govuk-checkboxes govuk-checkboxes--small iai-panel__scrollable" data-module="govuk-checkboxes">
+              {% for file in completed_files %}
                 <div class="govuk-checkboxes__item">
                   <input class="govuk-checkboxes__input" id="file-{{ file.id }}" name="file-{{ file.id }}" type="checkbox" value="{{ file.id }}" {% if file.selected %}checked{% endif %}>
                   <label class="govuk-checkboxes__label govuk-body-s" for="file-{{ file.id }}">{{ file.original_file_name }}</label>
-                  <file-status data-id="{{ file.id }}"></file-status>
                 </div>
               {% endfor %}
+              {# files not yet ready - stored here to be moved to main list once ready #}
+              <div hidden>
+                {% for file in processing_files %}
+                  <div class="govuk-checkboxes__item">
+                    <input class="govuk-checkboxes__input" id="file-{{ file.id }}" name="file-{{ file.id }}" type="checkbox" value="{{ file.id }}" {% if file.selected %}checked{% endif %}>
+                    <label class="govuk-checkboxes__label govuk-body-s" for="file-{{ file.id }}">{{ file.original_file_name }}</label>
+                    <file-status data-id="{{ file.id }}"></file-status>
+                  </div>
+                {% endfor %}
+              </div>
             </div>
-          </div>
-        </fieldset>
-      </document-selector>
+          </fieldset>
+        </document-selector>
 
+      </div>
     </div>
 
     <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Context

For long chat messages, users have to scroll all the way up to select docs and view chat history. Making these panels sticky will solve that problem.

## Changes proposed in this pull request

* Make the panels sticky
* Make the panel heights be based on available vertical screen space


## Guidance to review

* Go to a long chat and scroll up and down
* Check on a few different screen sizes if possible


## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-628


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
