### PR TITLE
Added ingress rule to django and core-api ecs tasks for lambdas

### DIFF
--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -246,3 +246,21 @@ resource "aws_security_group_rule" "ecs_ingress_worker_to_unstructured" {
   source_security_group_id = module.worker.ecs_sg_id
   security_group_id        = module.unstructured.ecs_sg_id
 }
+
+resource "aws_security_group_rule" "allow_lambdas_ingress_to_django" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  source_security_group_id = aws_security_group.django_lambda_security_group.id
+  security_group_id = module.django-app.ecs_sg_id
+}
+
+resource "aws_security_group_rule" "allow_lambdas_ingress_to_core" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  source_security_group_id = aws_security_group.django_lambda_security_group.id
+  security_group_id = module.core_api.ecs_sg_id
+}


### PR DESCRIPTION
## Context

The lambdas in prod look like they're failing, I tried to add this manually and it worked in access analyzer

## Changes proposed in this pull request

- Add ingress rule for lambdas to django ecs
- Add ingress rule for lambdas to core-api ecs

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
