### PR TITLE
Feature/empty docs tables

### DIFF
--- a/django_app/frontend/src/js/web-components/documents/doc-list.js
+++ b/django_app/frontend/src/js/web-components/documents/doc-list.js
@@ -3,12 +3,32 @@
 /** So completed docs can be added to this list */
 class DocList extends HTMLElement {
   connectedCallback() {
+    // Setup screen-reader announcements
+    let screenReaderAnnouncements = document.createElement("div");
+    /** @type {number} */
+    let screenReaderAnnouncementsTimer;
+    screenReaderAnnouncements.role = "alert";
+    screenReaderAnnouncements.setAttribute("aria-live", "assertive");
+    screenReaderAnnouncements.classList.add("govuk-visually-hidden");
+    this.appendChild(screenReaderAnnouncements);
+
     document.body.addEventListener("doc-complete", (evt) => {
+      // Move completed doc to this list
       const completedDoc = /** @type{CustomEvent} */ (evt).detail.closest(
         ".iai-doc-list__item"
       );
       completedDoc.querySelector("file-status").remove();
       this.querySelector("tbody")?.appendChild(completedDoc);
+
+      // Announce doc is ready to screen-reader users
+      const docName = completedDoc.querySelector(
+        ".iai-doc-list__cell--file-name"
+      ).textContent;
+      screenReaderAnnouncements.textContent = `Processing Complete: ${docName}`;
+      clearTimeout(screenReaderAnnouncementsTimer);
+      screenReaderAnnouncementsTimer = window.setTimeout(() => {
+        screenReaderAnnouncements.textContent = "";
+      }, 1);
     });
   }
 }

--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -69,45 +69,6 @@ body {
   filter: brightness(0.9);
 }
 
-/* Documents page */
-.rb-doc-retention {
-  align-items: center;
-  display: flex;
-  gap: 0.5rem;
-}
-.rb-doclist-mobile__item {
-  border: 1px solid #b1b4b6;
-  border-radius: 0.25rem;
-  list-style-type: none;
-}
-.rb-doclist-desktop {
-  display: none;
-}
-@media (min-width: 448px) {
-  .rb-doclist-mobile {
-    display: none;
-  }
-  .rb-doclist-desktop {
-    display: block;
-  }
-}
-/* Use this if more than one button in Actions
-.rb-docs__actions .govuk-button {
-  width: 100%;
-}
-@media (min-width: 1024px) {
-  .rb-docs__actions {
-    width: 13.25rem;
-  }
-  .rb-docs__actions .govuk-button {
-    width: auto;
-  }
-}
-.rb-docs__status {
-  margin-top: 2px;
-}
-
-
 /* File upload */
 .rb-file-types {
   font-size: 0.875rem;
@@ -139,6 +100,28 @@ upload-button {
   --iai-background-colour-2: #f8f8f8;
 }
 @import "../node_modules/i.ai-design-system/dist/styles.scss";
+
+/* Documents page - to come after i.AI Design System */
+.rb-doc-retention {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+.iai-doc-list {
+  display: none;
+}
+.iai-doc-list:has(.iai-doc-list__item) {
+  display: block;
+}
+.rb-docs__show-if-docs {
+  display: none;
+}
+.rb-docs:has(.iai-doc-list__item) .rb-docs__show-if-docs {
+  display: block;
+}
+.rb-docs:has(.iai-doc-list__item) .rb-docs__show-if-no-docs {
+  display: none;
+}
 
 /* Chats Page - to come after i.AI Design System */
 @import "./chat-styles.scss";

--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -49,27 +49,30 @@
       #}
 
       {# New Docs list #}
-      {% if completed_files or processing_files %}
-        <h2 class="govuk-heading-m">Ready to use</h2>
-        <p>These documents are ready to chat with. Documents are deleted after 30 days</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">Ready to use</h2>
+      <div class="rb-docs">
+        <p class="rb-docs__show-if-no-docs">Documents that are ready to chat with will be displayed here.</p>
+        <p class="rb-docs__show-if-docs">These documents are ready to chat with. Documents are deleted after 30 days.</p>
         <doc-list>
           {{ iaiDocList(
             docs = completed_files,
             type = "complete"
           ) }}
         </doc-list>
-      {% endif %}
+      </div>
 
-      {% if processing_files %}
-        <h2 class="govuk-heading-m govuk-!-margin-top-7">Processing</h2>
-        <p>These documents will not be included in chat responses</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">Processing</h2>
+      <div class="rb-docs">
+        <p class="rb-docs__show-if-no-docs">Uploaded files that are processing will be displayed here.</p>
+        <p class="rb-docs__show-if-docs">These documents will not be included in chat responses.</p>
         {{ iaiDocList(
           docs = processing_files,
           type = "processing"
         ) }}
-      {% endif %}
+      </div>
 
-      <div class="govuk-button-group govuk-!-margin-top-7">
+      <h2 class="govuk-visually-hidden">General actions</h2>
+      <div class="govuk-button-group govuk-!-margin-top-8">
         {% if completed_files or processing_files %}
           {{ govukButton(
             text="Start chat",


### PR DESCRIPTION
## Context

Making it clearer when a documents table is empty, so users understand what is happening.


## Changes proposed in this pull request

* The two tables (completed and processing docs) show a different line of text when that section is empty
* The actual table is now hidden when empty
* Bonus update: announce to screen-reader users when a document has completed


## Guidance to review

* For both tables, check that the text makes sense when empty vs when it contains docs


## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-630


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
