### PR TITLE
Tracking tokens in state object

### DIFF
--- a/core-api/core_api/routes/chat.py
+++ b/core-api/core_api/routes/chat.py
@@ -10,7 +10,7 @@ from fastapi.encoders import jsonable_encoder
 from openai import APIError, RateLimitError
 from langchain_core.documents import Document
 
-from redbox.models.chain import RedboxQuery, RedboxState, ChainChatMessage
+from redbox.models.chain import RedboxQuery, RedboxState, ChainChatMessage, RequestMetadata
 from redbox.models.chat import ChatRequest, ChatResponse, ClientResponse, ErrorDetail
 from redbox.transform import map_document_to_source_document
 
@@ -103,12 +103,16 @@ async def rag_chat_streamed(
             websocket,
         )
 
+    async def on_metadata_available(metadata: RequestMetadata):
+        print(f"Request Metadata: {metadata}")
+
     try:
         await redbox.run(
             state,
             response_tokens_callback=on_llm_response,
             route_name_callback=on_route_choice,
             documents_callback=on_documents_available,
+            metadata_available_callback=on_metadata_available,
         )
     except RateLimitError as e:
         log.exception("Rate limit error", exc_info=e)

--- a/redbox-core/redbox/app.py
+++ b/redbox-core/redbox/app.py
@@ -37,6 +37,7 @@ class Redbox:
         response_tokens_callback=_default_callback,
         route_name_callback=_default_callback,
         documents_callback=_default_callback,
+        metadata_available_callback=_default_callback,
     ) -> RedboxState:
         final_state = None
         async for event in self.graph.astream_events(input, version="v2"):
@@ -52,6 +53,7 @@ class Redbox:
                 await documents_callback(event["data"]["output"])
             elif kind == "on_chain_end" and event["name"] == "LangGraph":
                 final_state = RedboxState(**event["data"]["output"])
+                await metadata_available_callback(final_state.get("metadata"))
         return final_state
 
     def get_available_keywords(self) -> dict[ChatRoute, str]:

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -180,11 +180,29 @@ class RedboxQuery(BaseModel):
     ai_settings: AISettings = Field(description="User request AI settings", default_factory=AISettings)
 
 
+class RequestMetadata(TypedDict):
+    input_tokens: int
+    output_tokens: int
+
+
+def metadata_reducer(current: RequestMetadata | None, update: RequestMetadata | None):
+    if current is None:
+        return update
+    if update is None:
+        return current
+    if "input_tokens" in update:
+        input_tokens = current.get("input_tokens", 0) + update["input_tokens"]
+    if "output_tokens" in update:
+        output_tokens = current.get("output_tokens", 0) + update["output_tokens"]
+    return RequestMetadata(input_tokens=input_tokens, output_tokens=output_tokens)
+
+
 class RedboxState(TypedDict):
     request: Required[RedboxQuery]
     documents: Annotated[NotRequired[DocumentState], document_reducer]
     text: NotRequired[str | None]
     route_name: NotRequired[str | None]
+    metadata: Annotated[NotRequired[dict], metadata_reducer]
 
 
 class PromptSet(StrEnum):

--- a/redbox-core/redbox/transform.py
+++ b/redbox-core/redbox/transform.py
@@ -1,7 +1,7 @@
 from langchain_core.documents import Document
 
 from redbox.models.chat import SourceDocument
-from redbox.models.chain import DocumentState
+from redbox.models.chain import DocumentState, RequestMetadata
 
 
 def map_document_to_source_document(d: Document) -> SourceDocument:
@@ -59,3 +59,23 @@ def flatten_document_state(documents: DocumentState) -> list[Document]:
     if not documents:
         return []
     return [document for group in documents.values() for document in group.values()]
+
+
+def to_request_metadata(response_metadata: dict):
+    """
+    Convert a Langchain ChatLLM response metadata dictionary
+    """
+    # If ChatOpenAI
+    if "token_usage" in response_metadata:
+        tokens = response_metadata["token_usage"]
+        return RequestMetadata(
+            input_tokens=tokens.get("prompt_tokens", -1), output_tokens=tokens.get("completion_tokens", -1)
+        )
+    # If ChatBedrock (Anthropic)
+    elif "usage" in response_metadata:
+        tokens = response_metadata["usage"]
+        return RequestMetadata(
+            input_tokens=tokens.get("prompt_tokens", -1), output_tokens=tokens.get("completion_tokens", -1)
+        )
+    else:
+        return None

--- a/redbox-core/tests/graph/test_state.py
+++ b/redbox-core/tests/graph/test_state.py
@@ -3,7 +3,7 @@ import pytest
 
 from langchain_core.documents import Document
 
-from redbox.models.chain import document_reducer
+from redbox.models.chain import RequestMetadata, document_reducer, metadata_reducer
 
 
 GROUP_IDS = [uuid4() for i in range(4)]
@@ -118,4 +118,39 @@ DOCUMENT_IDS = [uuid4() for i in range(10)]
 )
 def test_document_reducer(a, b, expected):
     result = document_reducer(a, b)
+    assert result == expected, f"Expected: {expected}. Result: {result}"
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        (
+            RequestMetadata(input_tokens=0, output_tokens=0),
+            RequestMetadata(input_tokens=10, output_tokens=10),
+            RequestMetadata(input_tokens=10, output_tokens=10),
+        ),
+        (
+            RequestMetadata(input_tokens=12, output_tokens=100),
+            RequestMetadata(input_tokens=10, output_tokens=10),
+            RequestMetadata(input_tokens=22, output_tokens=110),
+        ),
+        (
+            RequestMetadata(input_tokens=100, output_tokens=200),
+            RequestMetadata(input_tokens=0, output_tokens=10),
+            RequestMetadata(input_tokens=100, output_tokens=210),
+        ),
+        (
+            None,
+            RequestMetadata(input_tokens=10, output_tokens=100),
+            RequestMetadata(input_tokens=10, output_tokens=100),
+        ),
+        (
+            RequestMetadata(input_tokens=10, output_tokens=100),
+            None,
+            RequestMetadata(input_tokens=10, output_tokens=100),
+        ),
+    ],
+)
+def test_metadata_reducer(a, b, expected):
+    result = metadata_reducer(a, b)
     assert result == expected, f"Expected: {expected}. Result: {result}"


### PR DESCRIPTION
## Context

We want to be able to track the token usage of an individual request to Redbox and ultimately per chat/user

## Changes proposed in this pull request

Added a new metadata object to the graph state, this currently contains input and output tokens.
Update the token counts on every LLM call

## Guidance to review

This doesn't account for different LLMs, we should probably review this when we start using them. We would certainly need to account for using different LLMs in a single call (ie condense question with 4o-mini and the full context question with 4o) to allow proper cost tracking but we should also maybe record the LLM so as we switch in different releases we have a record?

This metadata doesn't go anywhere yet. Returning it to django could be done in a separate ticket, this work could make django more tolerant of the websocket event types it allows to support this work and future additions


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
