### PR TITLE
Feature/llm fallbacks

### DIFF
--- a/infrastructure/aws/data.tf
+++ b/infrastructure/aws/data.tf
@@ -80,14 +80,17 @@ locals {
 
     "AZURE_OPENAI_API_KEY_35T" : var.azure_openai_api_key_35t,
     "AZURE_OPENAI_ENDPOINT_35T" : var.azure_openai_endpoint_35t,
+    "AZURE_OPENAI_FALLBACK_ENDPOINT_35T" : var.azure_openai_fallback_endpoint_35t,
     "OPENAI_API_VERSION_35T" : var.openai_api_version_35t,
 
     "AZURE_OPENAI_API_KEY_4T" : var.azure_openai_api_key_4t,
     "AZURE_OPENAI_ENDPOINT_4T" : var.azure_openai_endpoint_4t,
+    "AZURE_OPENAI_FALLBACK_ENDPOINT_4T" : var.azure_openai_fallback_endpoint_4t,
     "OPENAI_API_VERSION_4T" : var.openai_api_version_4t,
 
     "AZURE_OPENAI_API_KEY_4O" : var.azure_openai_api_key_4o,
     "AZURE_OPENAI_ENDPOINT_4O" : var.azure_openai_endpoint_4o,
+    "AZURE_OPENAI_FALLBACK_ENDPOINT_4O" : var.azure_openai_fallback_endpoint_4o,
     "OPENAI_API_VERSION_4O" : var.openai_api_version_4o,
 
     "EMBEDDING_OPENAI_API_KEY": var.embedding_openai_api_key,

--- a/infrastructure/aws/data.tf
+++ b/infrastructure/aws/data.tf
@@ -79,16 +79,19 @@ locals {
     "ELASTIC__CLOUD_ID" : var.cloud_id,
 
     "AZURE_OPENAI_API_KEY_35T" : var.azure_openai_api_key_35t,
+    "AZURE_OPENAI_FALLBACK_API_KEY_35T" : var.azure_openai_fallback_api_key_35t,
     "AZURE_OPENAI_ENDPOINT_35T" : var.azure_openai_endpoint_35t,
     "AZURE_OPENAI_FALLBACK_ENDPOINT_35T" : var.azure_openai_fallback_endpoint_35t,
     "OPENAI_API_VERSION_35T" : var.openai_api_version_35t,
 
     "AZURE_OPENAI_API_KEY_4T" : var.azure_openai_api_key_4t,
+    "AZURE_OPENAI_FALLBACK_API_KEY_4T" : var.azure_openai_fallback_api_key_4t,
     "AZURE_OPENAI_ENDPOINT_4T" : var.azure_openai_endpoint_4t,
     "AZURE_OPENAI_FALLBACK_ENDPOINT_4T" : var.azure_openai_fallback_endpoint_4t,
     "OPENAI_API_VERSION_4T" : var.openai_api_version_4t,
 
     "AZURE_OPENAI_API_KEY_4O" : var.azure_openai_api_key_4o,
+    "AZURE_OPENAI_FALLBACK_API_KEY_4O" : var.azure_openai_fallback_api_key_4o,
     "AZURE_OPENAI_ENDPOINT_4O" : var.azure_openai_endpoint_4o,
     "AZURE_OPENAI_FALLBACK_ENDPOINT_4O" : var.azure_openai_fallback_endpoint_4o,
     "OPENAI_API_VERSION_4O" : var.openai_api_version_4o,

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -139,6 +139,12 @@ variable "azure_openai_endpoint_35t" {
   description = "The base URL for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
 }
 
+variable "azure_openai_fallback_endpoint_35t" {
+  type        = string
+  default     = null
+  description = "The base URL for your fallback Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
+}
+
 variable "openai_api_version_4t" {
   type        = string
   default     = "2023-12-01-preview"
@@ -158,6 +164,12 @@ variable "azure_openai_endpoint_4t" {
   description = "The base URL for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
 }
 
+variable "azure_openai_fallback_endpoint_4t" {
+  type        = string
+  default     = null
+  description = "The base URL for your fallback Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
+}
+
 variable "openai_api_version_4o" {
   type        = string
   default     = "2023-12-01-preview"
@@ -175,6 +187,12 @@ variable "azure_openai_endpoint_4o" {
   type        = string
   default     = null
   description = "The base URL for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
+}
+
+variable "azure_openai_fallback_endpoint_4o" {
+  type        = string
+  default     = null
+  description = "The base URL for your fallback Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
 }
 
 variable "project_name" {

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -133,6 +133,13 @@ variable "azure_openai_api_key_35t" {
   description = "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
 }
 
+variable "azure_openai_fallback_api_key_35t" {
+  type        = string
+  sensitive   = true
+  default     = null
+  description = "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
+}
+
 variable "azure_openai_endpoint_35t" {
   type        = string
   default     = null
@@ -158,6 +165,13 @@ variable "azure_openai_api_key_4t" {
   description = "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
 }
 
+variable "azure_openai_fallback_api_key_4t" {
+  type        = string
+  sensitive   = true
+  default     = null
+  description = "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
+}
+
 variable "azure_openai_endpoint_4t" {
   type        = string
   default     = null
@@ -177,6 +191,13 @@ variable "openai_api_version_4o" {
 }
 
 variable "azure_openai_api_key_4o" {
+  type        = string
+  sensitive   = true
+  default     = null
+  description = "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource."
+}
+
+variable "azure_openai_fallback_api_key_4o" {
   type        = string
   sensitive   = true
   default     = null

--- a/redbox-core/redbox/chains/components.py
+++ b/redbox-core/redbox/chains/components.py
@@ -26,7 +26,7 @@ def get_chat_llm(env: Settings, ai_settings: AISettings):
             chat_model = chat_model.with_fallbacks(
                 [
                     AzureChatOpenAI(
-                        api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
+                        api_key=convert_to_secret_str(env.azure_openai_fallback_api_key_35t),
                         azure_endpoint=env.azure_openai_fallback_endpoint_35t,
                         model=ai_settings.chat_backend,
                         api_version=env.openai_api_version_35t,
@@ -45,10 +45,10 @@ def get_chat_llm(env: Settings, ai_settings: AISettings):
             chat_model = chat_model.with_fallbacks(
                 [
                     AzureChatOpenAI(
-                        api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
+                        api_key=convert_to_secret_str(env.azure_openai_fallback_api_key_4t),
                         azure_endpoint=env.azure_openai_fallback_endpoint_4t,
                         model=ai_settings.chat_backend,
-                        api_version=env.openai_api_version_35t,
+                        api_version=env.openai_api_version_4t,
                     )
                 ]
             )
@@ -64,10 +64,10 @@ def get_chat_llm(env: Settings, ai_settings: AISettings):
             chat_model = chat_model.with_fallbacks(
                 [
                     AzureChatOpenAI(
-                        api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
+                        api_key=convert_to_secret_str(env.azure_openai_fallback_api_key_4o),
                         azure_endpoint=env.azure_openai_fallback_endpoint_4o,
                         model=ai_settings.chat_backend,
-                        api_version=env.openai_api_version_35t,
+                        api_version=env.openai_api_version_4o,
                     )
                 ]
             )

--- a/redbox-core/redbox/chains/components.py
+++ b/redbox-core/redbox/chains/components.py
@@ -23,14 +23,15 @@ def get_chat_llm(env: Settings, ai_settings: AISettings):
         )
         if env.azure_openai_fallback_endpoint_35t:
             chat_model.max_retries = 0
-            chat_model = chat_model.with_fallbacks([
-                AzureChatOpenAI(
-                    api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
-                    azure_endpoint=env.azure_openai_fallback_endpoint_35t,
-                    model=ai_settings.chat_backend,
-                    api_version=env.openai_api_version_35t,
-                )
-            ]
+            chat_model = chat_model.with_fallbacks(
+                [
+                    AzureChatOpenAI(
+                        api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
+                        azure_endpoint=env.azure_openai_fallback_endpoint_35t,
+                        model=ai_settings.chat_backend,
+                        api_version=env.openai_api_version_35t,
+                    )
+                ]
             )
     elif ai_settings.chat_backend == "gpt-4-turbo-2024-04-09":
         chat_model = AzureChatOpenAI(
@@ -41,14 +42,15 @@ def get_chat_llm(env: Settings, ai_settings: AISettings):
         )
         if env.azure_openai_fallback_endpoint_4t:
             chat_model.max_retries = 0
-            chat_model = chat_model.with_fallbacks([
-                AzureChatOpenAI(
-                    api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
-                    azure_endpoint=env.azure_openai_fallback_endpoint_4t,
-                    model=ai_settings.chat_backend,
-                    api_version=env.openai_api_version_35t,
-                )
-            ]
+            chat_model = chat_model.with_fallbacks(
+                [
+                    AzureChatOpenAI(
+                        api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
+                        azure_endpoint=env.azure_openai_fallback_endpoint_4t,
+                        model=ai_settings.chat_backend,
+                        api_version=env.openai_api_version_35t,
+                    )
+                ]
             )
     elif ai_settings.chat_backend == "gpt-4o":
         chat_model = AzureChatOpenAI(
@@ -59,14 +61,15 @@ def get_chat_llm(env: Settings, ai_settings: AISettings):
         )
         if env.azure_openai_fallback_endpoint_4o:
             chat_model.max_retries = 0
-            chat_model = chat_model.with_fallbacks([
-                AzureChatOpenAI(
-                    api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
-                    azure_endpoint=env.azure_openai_fallback_endpoint_4o,
-                    model=ai_settings.chat_backend,
-                    api_version=env.openai_api_version_35t,
-                )
-            ]
+            chat_model = chat_model.with_fallbacks(
+                [
+                    AzureChatOpenAI(
+                        api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
+                        azure_endpoint=env.azure_openai_fallback_endpoint_4o,
+                        model=ai_settings.chat_backend,
+                        api_version=env.openai_api_version_35t,
+                    )
+                ]
             )
     if chat_model is None:
         raise Exception("%s not recognised", ai_settings.chat_backend)

--- a/redbox-core/redbox/chains/components.py
+++ b/redbox-core/redbox/chains/components.py
@@ -13,28 +13,65 @@ from redbox.retriever import AllElasticsearchRetriever, ParameterisedElasticsear
 
 
 def get_chat_llm(env: Settings, ai_settings: AISettings):
+    chat_model = None
     if ai_settings.chat_backend == "gpt-35-turbo-16k":
-        return AzureChatOpenAI(
+        chat_model = AzureChatOpenAI(
             api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
             azure_endpoint=env.azure_openai_endpoint_35t,
             model=ai_settings.chat_backend,
             api_version=env.openai_api_version_35t,
         )
+        if env.azure_openai_fallback_endpoint_35t:
+            chat_model.max_retries = 0
+            chat_model = chat_model.with_fallbacks([
+                AzureChatOpenAI(
+                    api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
+                    azure_endpoint=env.azure_openai_fallback_endpoint_35t,
+                    model=ai_settings.chat_backend,
+                    api_version=env.openai_api_version_35t,
+                )
+            ]
+            )
     elif ai_settings.chat_backend == "gpt-4-turbo-2024-04-09":
-        return AzureChatOpenAI(
+        chat_model = AzureChatOpenAI(
             api_key=convert_to_secret_str(env.azure_openai_api_key_4t),
             azure_endpoint=env.azure_openai_endpoint_4t,
             model=ai_settings.chat_backend,
             api_version=env.openai_api_version_4t,
         )
+        if env.azure_openai_fallback_endpoint_4t:
+            chat_model.max_retries = 0
+            chat_model = chat_model.with_fallbacks([
+                AzureChatOpenAI(
+                    api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
+                    azure_endpoint=env.azure_openai_fallback_endpoint_4t,
+                    model=ai_settings.chat_backend,
+                    api_version=env.openai_api_version_35t,
+                )
+            ]
+            )
     elif ai_settings.chat_backend == "gpt-4o":
-        return AzureChatOpenAI(
+        chat_model = AzureChatOpenAI(
             api_key=convert_to_secret_str(env.azure_openai_api_key_4o),
             azure_endpoint=env.azure_openai_endpoint_4o,
             model=ai_settings.chat_backend,
             api_version=env.openai_api_version_4o,
         )
-    raise Exception("%s not recognised", ai_settings.chat_backend)
+        if env.azure_openai_fallback_endpoint_4o:
+            chat_model.max_retries = 0
+            chat_model = chat_model.with_fallbacks([
+                AzureChatOpenAI(
+                    api_key=convert_to_secret_str(env.azure_openai_api_key_35t),
+                    azure_endpoint=env.azure_openai_fallback_endpoint_4o,
+                    model=ai_settings.chat_backend,
+                    api_version=env.openai_api_version_35t,
+                )
+            ]
+            )
+    if chat_model is None:
+        raise Exception("%s not recognised", ai_settings.chat_backend)
+    else:
+        return chat_model
 
 
 @cache

--- a/redbox-core/redbox/models/settings.py
+++ b/redbox-core/redbox/models/settings.py
@@ -40,18 +40,21 @@ class Settings(BaseSettings):
     # azure/gpt-35-turbo-16k
     openai_api_version_35t: str = "2023-12-01-preview"
     azure_openai_api_key_35t: str = "not a key"
+    azure_openai_fallback_api_key_35t: str = "not a key"
     azure_openai_endpoint_35t: str = "not an endpoint"
     azure_openai_fallback_endpoint_35t: str | None = None
 
     # azure/gpt-4
     openai_api_version_4t: str = "2024-02-01"
     azure_openai_api_key_4t: str = "not a key"
+    azure_openai_fallback_api_key_4t: str = "not a key"
     azure_openai_endpoint_4t: str = "not an endpoint"
     azure_openai_fallback_endpoint_4t: str | None = None
 
     # azure/gpt-4o
     openai_api_version_4o: str = "2024-02-01"
     azure_openai_api_key_4o: str = "not a key"
+    azure_openai_fallback_api_key_4o: str = "not a key"
     azure_openai_endpoint_4o: str = "not an endpoint"
     azure_openai_fallback_endpoint_4o: str | None = None
 

--- a/redbox-core/redbox/models/settings.py
+++ b/redbox-core/redbox/models/settings.py
@@ -41,16 +41,19 @@ class Settings(BaseSettings):
     openai_api_version_35t: str = "2023-12-01-preview"
     azure_openai_api_key_35t: str = "not a key"
     azure_openai_endpoint_35t: str = "not an endpoint"
+    azure_openai_fallback_endpoint_35t: str | None = None
 
     # azure/gpt-4
     openai_api_version_4t: str = "2024-02-01"
     azure_openai_api_key_4t: str = "not a key"
     azure_openai_endpoint_4t: str = "not an endpoint"
+    azure_openai_fallback_endpoint_4t: str | None = None
 
     # azure/gpt-4o
     openai_api_version_4o: str = "2024-02-01"
     azure_openai_api_key_4o: str = "not a key"
     azure_openai_endpoint_4o: str = "not an endpoint"
+    azure_openai_fallback_endpoint_4o: str | None = None
 
     embedding_openai_api_key: str = "NotAKey"
     embedding_azure_openai_endpoint: str = "not an endpoint"


### PR DESCRIPTION
## Context

We hit rate limits a lot, we should try to use our capacity in other regions when this happens

## Changes proposed in this pull request

Use Langchain fallbacks to use the same model, in the same account but a different region when we hit errors

## Guidance to review

Is the env var stuff setup right? It should do nothing if the new env var isn't set and we should only be able to do cross region failover so there's no danger of secretly switching models.

There are no tests for this because scenario setup is hard to do and very hard to test for as the switch should be invisible to any caller

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
