### PR TITLE
Added env integration layer to django and db in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,10 @@ services:
     networks:
       - redbox-app-network
     env_file:
-      - .env
+      - path: .env.integration
+        required: false
+      - path: .env
+        required: false
     volumes:
       - /app/django_app/frontend/node_modules
       - ./django_app:/app/django_app/
@@ -35,7 +38,10 @@ services:
   db:
     image: postgres:13
     env_file:
-      - .env
+      - path: .env.integration
+        required: false
+      - path: .env
+        required: false
     volumes:
       - local_postgres_data:/var/lib/postgresql/data:Z
     networks:


### PR DESCRIPTION
## Context

We want to allow clean usage of env files in different places. We're currently not using env integration for django in docker-compose

## Changes proposed in this pull request

Use .env.integration and .env in django and db in docker-compose rather than just .env. This means .env can leave any hosts out to allow also using it in unit tests and vscode launch profiles without issue.

## Guidance to review

This shouldn't affect anyone who isn't using vscode launch profiles and docker compose. Any questions about env let me know, could be worth a write up on how we're using them across the different ways to run

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
