### PR TITLE
bugfix/switched to original_file_name

### DIFF
--- a/django_app/redbox_app/redbox_core/serializers.py
+++ b/django_app/redbox_app/redbox_core/serializers.py
@@ -6,7 +6,7 @@ from redbox_app.redbox_core.models import Chat, ChatMessage, ChatMessageTokenUse
 class FileSerializer(serializers.ModelSerializer):
     class Meta:
         model = File
-        fields = ("unique_name",)
+        fields = ("original_file_name",)
 
 
 class ChatMessageTokenUseSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Context

we have a longstanding issue with the unique_file_name which can throw an error when the original_file is null, as a stop gap we shall use the original_file_name in our analysis

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
