### PR TITLE
feature/added parameters for django-q

### DIFF
--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -337,8 +337,9 @@ REDBOX_VERSION = os.environ.get("REDBOX_VERSION", "not set")
 
 Q_CLUSTER = {
     "name": "redbox_django",
-    "timeout": 120,
-    "retry": 600,
+    "timeout": os.environ.get("Q_TIMEOUT", 300),
+    "retry": os.environ.get("Q_RETRY", 900),
+    "max_attempts": os.environ.get("Q_MAX_ATTEMPTS", 3),
     "catch_up": False,
     "orm": "default",
 }

--- a/infrastructure/aws/data.tf
+++ b/infrastructure/aws/data.tf
@@ -35,6 +35,9 @@ locals {
   django_app_environment_variables = merge({
     "AWS_REGION" : var.region,
     "UNSTRUCTURED_HOST" : local.unstructured_host
+    "Q_TIMEOUT": var.django_queue_timeout,
+    "Q_RETRY": var.django_queue_retry,
+    "Q_MAX_ATTEMPTS": var.django_queue_max_attempts
     }, local.django_lambda_environment_variables
     , local.worker_environment_variables,
   )

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -499,6 +499,6 @@ variable "django_queue_retry" {
 
 variable "django_queue_max_attempts" {
   type        = number
-  default     = 300
+  default     = 3
   description = "How many attempts to run unstructured task"
 }

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -484,3 +484,21 @@ variable "worker_ingest_largest_chunk_overlap" {
   default     = 0
   description = "Largest chunk resolution. Size of overlap between chunks produced by the worker"
 }
+
+variable "django_queue_timeout" {
+  type        = number
+  default     = 300
+  description = "How long to wait for unstructured to complete task"
+}
+
+variable "django_queue_retry" {
+  type        = number
+  default     = 300
+  description = "How long to wait between retrying unstructured task"
+}
+
+variable "django_queue_max_attempts" {
+  type        = number
+  default     = 300
+  description = "How many attempts to run unstructured task"
+}


### PR DESCRIPTION
## Context

As an Engineer I want to:
* increase the timeout for the unstructured tasks
* set a max_retry 
* set these parameters from env vars so that we dont have to rebuild every time we want to change a paremter

Large files are more likely to succeed given enough time, but we dont indefinitely retry for file that are too large for the timeout


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
