### PR TITLE
Fixing type issues in redbox emitted events

### DIFF
--- a/redbox-core/redbox/app.py
+++ b/redbox-core/redbox/app.py
@@ -44,9 +44,13 @@ class Redbox:
             kind = event["event"]
             tags = event.get("tags", [])
             if kind == "on_chat_model_stream" and FINAL_RESPONSE_TAG in tags:
-                await response_tokens_callback(event["data"]["chunk"].content)
+                content = event["data"]["chunk"].content
+                if isinstance(content, str):
+                    await response_tokens_callback(content)
             elif kind == "on_chain_end" and FINAL_RESPONSE_TAG in tags:
-                await response_tokens_callback(event["data"]["output"])
+                content = event["data"]["output"]
+                if isinstance(content, str):
+                    await response_tokens_callback(content)
             elif kind == "on_chain_end" and ROUTE_NAME_TAG in tags:
                 await route_name_callback(event["data"]["output"])
             elif kind == "on_retriever_end" and SOURCE_DOCUMENTS_TAG in tags:

--- a/redbox-core/redbox/models/chat.py
+++ b/redbox-core/redbox/models/chat.py
@@ -84,8 +84,8 @@ class ChatResponse(BaseModel):
 
 
 class MetadataDetail(BaseModel):
-    input_tokens: dict[str, int] | None = None
-    output_tokens: dict[str, int] | None = None
+    input_tokens: dict[str, int] = Field(default_factory=dict)
+    output_tokens: dict[str, int] = Field(default_factory=dict)
 
 
 class ErrorDetail(BaseModel):

--- a/redbox-core/redbox/transform.py
+++ b/redbox-core/redbox/transform.py
@@ -101,7 +101,7 @@ def to_request_metadata(prompt_response_model: dict):
     input_tokens = {model: len(tokeniser.encode(prompt_response_model["prompt"]))}
     output_tokens = {model: len(tokeniser.encode(prompt_response_model["response"]))}
 
-    dispatch_custom_event("on_metadata_generation", {"input_tokens": input_tokens})
-    dispatch_custom_event("on_metadata_generation", {"output_tokens": output_tokens})
+    dispatch_custom_event("on_metadata_generation", RequestMetadata(input_tokens=input_tokens, output_tokens=dict()))
+    dispatch_custom_event("on_metadata_generation", RequestMetadata(input_tokens=dict(), output_tokens=output_tokens))
 
     return RequestMetadata(input_tokens=input_tokens, output_tokens=output_tokens)


### PR DESCRIPTION
## Context

We aren't getting input tokens sent to the django app. These are handled as dispatched events in redbox-core

## Changes proposed in this pull request

Fixing some type issues in emitted events. This seems to fix the issue locally. Still not exactly clear how this caused the issue so I'll keep looking at this but this is certainly a bug

## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
