### PR TITLE
Update make command for dynamo lock table 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,10 @@ tf_set_or_create_workspace:
 
 .PHONY: tf_init
 tf_init: ## Initialise terraform
-	terraform -chdir=./infrastructure/aws/$(instance) init -backend-config=$(TF_BACKEND_CONFIG) ${args}
+	terraform -chdir=./infrastructure/aws/$(instance) init  \
+	-backend-config="dynamodb_table=i-dot-ai-$(env)-dynamo-lock" \
+	-backend-config=$(TF_BACKEND_CONFIG) \
+	${args}
 
 .PHONY: tf_plan
 tf_plan: ## Plan terraform


### PR DESCRIPTION
## Context

Related to https://github.com/i-dot-ai/redbox-copilot-infra-config/pull/20

We are setting up a DynamoDB lock table for each environment and specifying the environment-specific table as a parameter during the Terraform initialization process.


## Changes proposed in this pull request

Adding dynamodb table name as a parameter during the Terraform initialization process.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links

https://github.com/i-dot-ai/redbox-copilot-infra-config/pull/20

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
