### PR TITLE
Feature/removed user UUID from metatdata

### DIFF
--- a/core-api/tests/conftest.py
+++ b/core-api/tests/conftest.py
@@ -10,7 +10,7 @@ from jose import jwt
 from langchain_core.documents.base import Document
 from langchain_core.embeddings.fake import FakeEmbeddings
 from langchain_elasticsearch.vectorstores import ElasticsearchStore
-from redbox.models import File, Settings
+from redbox.models import Settings
 from redbox.models.file import ChunkMetadata, ChunkResolution
 
 from core_api import dependencies
@@ -109,23 +109,21 @@ def file_pdf_path() -> Path:
 
 
 @pytest.fixture()
-def file_pdf_object(file_pdf_path: Path, alice: UUID, env: Settings) -> File:
+def file_pdf(file_pdf_path: Path, alice: UUID, env: Settings) -> str:
     """The unuploaded File object of Alice's PDF."""
     file_name = file_pdf_path.name
-    return File(key=file_name, bucket=env.bucket_name, creator_user_uuid=alice)
+    return file_name
 
 
 @pytest.fixture()
-def file_pdf_chunks(file_pdf_object: File) -> list[Document]:
+def file_pdf_chunks(file_pdf) -> list[Document]:
     """The Document chunk objects of Alice's PDF."""
     normal_chunks = [
         Document(
             page_content="hello",
             metadata=ChunkMetadata(
-                parent_file_uuid=str(file_pdf_object.uuid),
                 index=i,
-                file_name=file_pdf_object.key,
-                creator_user_uuid=file_pdf_object.creator_user_uuid,
+                file_name=file_pdf,
                 page_number=4,
                 created_datetime=datetime.now(UTC),
                 token_count=4,
@@ -139,10 +137,8 @@ def file_pdf_chunks(file_pdf_object: File) -> list[Document]:
         Document(
             page_content="hello" * 10,
             metadata=ChunkMetadata(
-                parent_file_uuid=str(file_pdf_object.uuid),
                 index=i,
-                file_name=file_pdf_object.key,
-                creator_user_uuid=file_pdf_object.creator_user_uuid,
+                file_name=file_pdf,
                 page_number=4,
                 created_datetime=datetime.now(UTC),
                 token_count=20,
@@ -161,23 +157,21 @@ def file_html_path() -> Path:
 
 
 @pytest.fixture()
-def file_html_object(file_html_path: Path, alice: UUID, env: Settings) -> File:
+def file_html(file_html_path: Path, alice: UUID, env: Settings) -> str:
     """The unuploaded File object of Alice's HTML."""
     file_name = file_html_path.name
-    return File(key=file_name, bucket=env.bucket_name, creator_user_uuid=alice)
+    return file_name
 
 
 @pytest.fixture()
-def file_html_chunks(file_html_object: File) -> list[Document]:
+def file_html_chunks(file_html: str) -> list[Document]:
     """The Document chunk objects of Alice's HTML."""
     normal_chunks = [
         Document(
             page_content="hello",
             metadata=ChunkMetadata(
-                parent_file_uuid=str(file_html_object.uuid),
                 index=i,
-                file_name=file_html_object.key,
-                creator_user_uuid=file_html_object.creator_user_uuid,
+                file_name=file_html,
                 page_number=4,
                 created_datetime=datetime.now(UTC),
                 token_count=4,
@@ -191,10 +185,8 @@ def file_html_chunks(file_html_object: File) -> list[Document]:
         Document(
             page_content="hello" * 10,
             metadata=ChunkMetadata(
-                parent_file_uuid=str(file_html_object.uuid),
                 index=i,
-                file_name=file_html_object.key,
-                creator_user_uuid=file_html_object.creator_user_uuid,
+                file_name=file_html,
                 page_number=4,
                 created_datetime=datetime.now(UTC),
                 token_count=20,

--- a/django_app/redbox_app/worker.py
+++ b/django_app/redbox_app/worker.py
@@ -1,10 +1,7 @@
 import logging
 from uuid import UUID
 
-from django.conf import settings
-
 from redbox.loader.ingester import ingest_file
-from redbox.models import File as CoreFile
 
 
 def ingest(file_id: UUID):
@@ -15,12 +12,7 @@ def ingest(file_id: UUID):
 
     logging.info("Ingesting file: %s", file)
 
-    core_file = CoreFile(
-        key=file.unique_name,
-        bucket=settings.BUCKET_NAME,
-        creator_user_uuid=file.user.id,
-    )
-    if error := ingest_file(core_file):
+    if error := ingest_file(file.unique_name):
         file.status = StatusEnum.errored
         file.ingest_error = error
     else:

--- a/redbox-core/redbox/chains/ingest.py
+++ b/redbox-core/redbox/chains/ingest.py
@@ -8,7 +8,6 @@ from langchain_core.documents.base import Document
 from langchain_core.runnables import RunnableLambda, chain, Runnable
 
 from redbox.models.settings import Settings
-from redbox.models.file import File
 from redbox.loader.base import BaseRedboxFileLoader
 
 
@@ -29,9 +28,9 @@ def log_chunks(chunks: list[Document]):
 
 def document_loader(document_loader_type: type[BaseRedboxFileLoader], s3_client: S3Client, env: Settings) -> Runnable:
     @chain
-    def wrapped(file: File):
-        file_bytes = s3_client.get_object(Bucket=env.bucket_name, Key=file.key)["Body"].read()
-        return document_loader_type(file=file, file_bytes=BytesIO(file_bytes), env=env).lazy_load()
+    def wrapped(file_name: str):
+        file_bytes = s3_client.get_object(Bucket=env.bucket_name, Key=file_name)["Body"].read()
+        return document_loader_type(file_name=file_name, file_bytes=BytesIO(file_bytes), env=env).lazy_load()
 
     return wrapped
 

--- a/redbox-core/redbox/chains/ingest.py
+++ b/redbox-core/redbox/chains/ingest.py
@@ -30,7 +30,7 @@ def log_chunks(chunks: list[Document]):
 def document_loader(document_loader_type: type[BaseRedboxFileLoader], s3_client: S3Client, env: Settings) -> Runnable:
     @chain
     def wrapped(file: File):
-        file_bytes = s3_client.get_object(Bucket=file.bucket, Key=file.key)["Body"].read()
+        file_bytes = s3_client.get_object(Bucket=env.bucket_name, Key=file.key)["Body"].read()
         return document_loader_type(file=file, file_bytes=BytesIO(file_bytes), env=env).lazy_load()
 
     return wrapped

--- a/redbox-core/redbox/loader/base.py
+++ b/redbox-core/redbox/loader/base.py
@@ -2,17 +2,16 @@ from io import BytesIO
 
 from langchain_core.document_loaders import BaseLoader
 
-from redbox.models.file import File
 from redbox.models.settings import Settings
 
 
 class BaseRedboxFileLoader(BaseLoader):
-    def __init__(self, file: File, file_bytes: BytesIO, env: Settings) -> None:
+    def __init__(self, file_name: str, file_bytes: BytesIO, env: Settings) -> None:
         """Initialize the loader with a file path.
 
         Args:
             file: The Redbox File to load
         """
-        self.file = file
+        self.file_name = file_name
         self.file_bytes = file_bytes
         self.env = env

--- a/redbox-core/redbox/loader/ingester.py
+++ b/redbox-core/redbox/loader/ingester.py
@@ -7,7 +7,6 @@ from langchain_elasticsearch.vectorstores import BM25Strategy, ElasticsearchStor
 from redbox.chains.components import get_embeddings
 from redbox.chains.ingest import ingest_from_loader
 from redbox.loader import UnstructuredLargeChunkLoader, UnstructuredTitleLoader
-from redbox.models import File
 from redbox.models import Settings
 
 if TYPE_CHECKING:
@@ -35,8 +34,8 @@ def get_elasticsearch_store_without_embeddings(es, es_index_name: str):
     return ElasticsearchStore(index_name=es_index_name, es_connection=es, query_field="text", strategy=BM25Strategy())
 
 
-def ingest_file(core_file: File) -> str | None:
-    logging.info("Ingesting file: %s", core_file)
+def ingest_file(file_name: str) -> str | None:
+    logging.info("Ingesting file: %s", file_name)
 
     es = env.elasticsearch_client()
     es_index_name = f"{env.elastic_root_index}-chunk"
@@ -59,9 +58,9 @@ def ingest_file(core_file: File) -> str | None:
 
     try:
         new_ids = RunnableParallel({"normal": chunk_ingest_chain, "largest": large_chunk_ingest_chain}).invoke(
-            core_file
+            file_name
         )
-        logging.info("File: %s %s chunks ingested", core_file, {k: len(v) for k, v in new_ids.items()})
+        logging.info("File: %s %s chunks ingested", file_name, {k: len(v) for k, v in new_ids.items()})
     except Exception as e:
-        logging.exception("Error while processing file [%s]", core_file)
+        logging.exception("Error while processing file [%s]", file_name)
         return f"{type(e)}: {e.args[0]}"

--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -29,7 +29,7 @@ class UnstructuredLargeChunkLoader(BaseRedboxFileLoader):
 
         url = f"http://{self.env.unstructured_host}:8000/general/v0/general"
         files = {
-            "files": (self.file.key, self.file_bytes),
+            "files": (self.file_name, self.file_bytes),
         }
         response = requests.post(
             url,
@@ -77,7 +77,7 @@ class UnstructuredTitleLoader(BaseRedboxFileLoader):
         url = f"http://{self.env.unstructured_host}:8000/general/v0/general"
 
         files = {
-            "files": (self.file.key, self.file_bytes),
+            "files": (self.file_name, self.file_bytes),
         }
         response = requests.post(
             url,

--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -54,7 +54,6 @@ class UnstructuredLargeChunkLoader(BaseRedboxFileLoader):
             yield Document(
                 page_content=raw_chunk["text"],
                 metadata=ChunkMetadata(
-                    creator_user_uuid=self.file.creator_user_uuid,
                     index=i,
                     file_name=raw_chunk["metadata"].get("filename"),
                     page_number=raw_chunk["metadata"].get("page_number"),
@@ -103,7 +102,6 @@ class UnstructuredTitleLoader(BaseRedboxFileLoader):
             yield Document(
                 page_content=raw_chunk["text"],
                 metadata=ChunkMetadata(
-                    creator_user_uuid=self.file.creator_user_uuid,
                     index=i,
                     file_name=raw_chunk["metadata"].get("filename"),
                     page_number=raw_chunk["metadata"].get("page_number"),

--- a/redbox-core/redbox/models/__init__.py
+++ b/redbox-core/redbox/models/__init__.py
@@ -1,5 +1,4 @@
 from redbox.models.chat import ChatMessage, ChatRequest, ChatResponse, ChatRoute
-from redbox.models.file import File
 from redbox.models.settings import Settings
 
 __all__ = [
@@ -7,6 +6,5 @@ __all__ = [
     "ChatRequest",
     "ChatResponse",
     "ChatRoute",
-    "File",
     "Settings",
 ]

--- a/redbox-core/redbox/models/file.py
+++ b/redbox-core/redbox/models/file.py
@@ -11,8 +11,6 @@ class File(BaseModel):
     """Reference to file stored on s3"""
 
     key: str = Field(description="file key")
-    bucket: str = Field(description="s3 bucket")
-    creator_user_uuid: UUID
 
 
 class ChunkResolution(StrEnum):
@@ -30,7 +28,6 @@ class ChunkMetadata(BaseModel):
     """
 
     uuid: UUID = Field(default_factory=uuid4)
-    creator_user_uuid: UUID
     index: int
     file_name: str
     page_number: int | None = None

--- a/redbox-core/redbox/models/file.py
+++ b/redbox-core/redbox/models/file.py
@@ -7,12 +7,6 @@ import datetime
 from pydantic import BaseModel, Field
 
 
-class File(BaseModel):
-    """Reference to file stored on s3"""
-
-    key: str = Field(description="file key")
-
-
 class ChunkResolution(StrEnum):
     smallest = "smallest"
     small = "small"

--- a/redbox-core/redbox/retriever/queries.py
+++ b/redbox-core/redbox/retriever/queries.py
@@ -1,5 +1,4 @@
 from typing import Any
-from uuid import UUID
 
 from langchain_core.embeddings.embeddings import Embeddings
 
@@ -7,29 +6,20 @@ from redbox.models.chain import RedboxState
 from redbox.models.file import ChunkResolution
 
 
-def make_query_filter(user_uuid: UUID, file_names: list[str], chunk_resolution: ChunkResolution | None) -> list[dict]:
-    query_filter: list[dict] = [
+def make_query_filter(file_names: list[str], chunk_resolution: ChunkResolution | None) -> list[dict]:
+    if not file_names:
+        return []
+
+    query_filter = [
         {
             "bool": {
                 "should": [
-                    {"term": {"creator_user_uuid.keyword": str(user_uuid)}},
-                    {"term": {"metadata.creator_user_uuid.keyword": str(user_uuid)}},
+                    {"terms": {"file_name.keyword": file_names}},
+                    {"terms": {"metadata.file_name.keyword": file_names}},
                 ]
             }
         }
     ]
-
-    if len(file_names) != 0:
-        query_filter.append(
-            {
-                "bool": {
-                    "should": [
-                        {"terms": {"file_name.keyword": file_names}},
-                        {"terms": {"metadata.file_name.keyword": file_names}},
-                    ]
-                }
-            }
-        )
 
     if chunk_resolution:
         query_filter.append(
@@ -54,7 +44,7 @@ def get_all(
     As it's used in summarisation, it excludes embeddings.
     """
 
-    query_filter = make_query_filter(state["request"].user_uuid, state["request"].s3_keys, chunk_resolution)
+    query_filter = make_query_filter(state["request"].s3_keys, chunk_resolution)
     return {
         "_source": {"excludes": ["*embedding"]},
         "query": {"bool": {"must": {"match_all": {}}, "filter": query_filter}},
@@ -69,7 +59,7 @@ def get_some(
 ) -> dict[str, Any]:
     vector = embedding_model.embed_query(state["request"].question)
 
-    query_filter = make_query_filter(state["request"].user_uuid, state["request"].s3_keys, chunk_resolution)
+    query_filter = make_query_filter(state["request"].s3_keys, chunk_resolution)
 
     return {
         "size": state["request"].ai_settings.rag_k,

--- a/redbox-core/tests/conftest.py
+++ b/redbox-core/tests/conftest.py
@@ -9,7 +9,7 @@ from elasticsearch import Elasticsearch
 import tiktoken
 from tiktoken.core import Encoding
 
-from redbox.models import File, Settings
+from redbox.models import Settings
 
 from collections.abc import Generator
 
@@ -152,7 +152,7 @@ def file_pdf_path() -> Path:
 
 
 @pytest.fixture()
-def file(s3_client: S3Client, file_pdf_path: Path, alice: UUID, env: Settings) -> File:
+def file(s3_client: S3Client, file_pdf_path: Path, alice: UUID, env: Settings) -> str:
     file_name = file_pdf_path.name
     file_type = file_pdf_path.suffix
 
@@ -164,7 +164,7 @@ def file(s3_client: S3Client, file_pdf_path: Path, alice: UUID, env: Settings) -
             Tagging=f"file_type={file_type}",
         )
 
-    return File(key=file_name, bucket=env.bucket_name)
+    return file_name
 
 
 @pytest.fixture(params=ALL_CHUNKS_RETRIEVER_CASES)

--- a/redbox-core/tests/conftest.py
+++ b/redbox-core/tests/conftest.py
@@ -164,7 +164,7 @@ def file(s3_client: S3Client, file_pdf_path: Path, alice: UUID, env: Settings) -
             Tagging=f"file_type={file_type}",
         )
 
-    return File(key=file_name, bucket=env.bucket_name, creator_user_uuid=alice)
+    return File(key=file_name, bucket=env.bucket_name)
 
 
 @pytest.fixture(params=ALL_CHUNKS_RETRIEVER_CASES)

--- a/redbox-core/tests/graph/test_patterns.py
+++ b/redbox-core/tests/graph/test_patterns.py
@@ -279,7 +279,7 @@ def test_empty_process():
     """Tests the empty process doesn't touch the state whatsoever."""
     state = RedboxState(
         request=RedboxQuery(question="What is AI?", s3_keys=[], user_uuid=uuid4(), chat_history=[]),
-        documents=structure_documents([doc for doc in generate_docs(s3_key="s3_key", creator_user_uuid=uuid4())]),
+        documents=structure_documents([doc for doc in generate_docs(s3_key="s3_key")]),
         text="Foo",
         route_name=ChatRoute.chat_with_docs_map_reduce,
     )
@@ -299,7 +299,7 @@ def test_empty_process():
 CLEAR_DOC_TEST_CASES = [
     RedboxState(
         request=RedboxQuery(question="What is AI?", file_uuids=[], user_uuid=uuid4(), chat_history=[]),
-        documents=structure_documents([doc for doc in generate_docs(s3_key="s3_key", creator_user_uuid=uuid4())]),
+        documents=structure_documents([doc for doc in generate_docs(s3_key="s3_key")]),
         text="Foo",
         route_name=ChatRoute.chat_with_docs_map_reduce,
     ),


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

1. The `File` object has been replace with `file_name` which is globally unique
2. `parent_file_uuid` `creator_user_uuid` have been removed from `ChunkMetadata`, so that `file_name` is now the only way to identify the `ChunkMetadata`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
