### PR TITLE
No longer show error messages for routes

### DIFF
--- a/core-api/tests/routes/test_chat.py
+++ b/core-api/tests/routes/test_chat.py
@@ -112,13 +112,13 @@ TEST_CASES = [
             ),
             test_data=[
                 RedboxTestData(
-                    2,
-                    200_000,
-                    expected_llm_response=["That keyword isn't recognised"],
-                    expected_route=ChatRoute.error_no_keyword,
+                    1,
+                    50_000,
+                    expected_llm_response=["Testing Response 1"],
+                    expected_route=ChatRoute.chat_with_docs,
                 ),
             ],
-            test_id="No Such Keyword",
+            test_id="No Such Keyword with file",
         ),
     ]
     for test_case in generated_cases

--- a/redbox-core/redbox/graph/edges.py
+++ b/redbox-core/redbox/graph/edges.py
@@ -82,7 +82,7 @@ def build_keyword_detection_conditional(*allowed_routes: ChatRoute) -> Runnable:
                 return route
         except KeyError:
             if route_name is not None:
-                return ChatRoute.error_no_keyword
+                return "DEFAULT"
 
         return "DEFAULT"
 

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -203,17 +203,6 @@ def get_root_graph(
 
     # Processes
     builder.add_node("p_search", rag_subgraph)
-    builder.add_node(
-        "p_no_keyword_error",
-        build_set_text_pattern(
-            text="That keyword isn't recognised",  # TODO: replace with env
-            final_response_chain=True,
-        ),
-    )
-    builder.add_node(
-        "p_no_keyword_route",
-        build_set_route_pattern(route=ChatRoute.error_no_keyword),
-    )
     builder.add_node("p_chat", chat_subgraph)
     builder.add_node("p_chat_with_documents", cwd_subgraph)
 
@@ -226,7 +215,7 @@ def get_root_graph(
     builder.add_conditional_edges(
         "d_keyword_exists",
         build_keyword_detection_conditional(*ROUTABLE_KEYWORDS.keys()),
-        {ChatRoute.search: "p_search", ChatRoute.error_no_keyword: "p_no_keyword_error", "DEFAULT": "d_docs_selected"},
+        {ChatRoute.search: "p_search", "DEFAULT": "d_docs_selected"},
     )
     builder.add_conditional_edges(
         "d_docs_selected",
@@ -237,8 +226,6 @@ def get_root_graph(
         },
     )
     builder.add_edge("p_search", END)
-    builder.add_edge("p_no_keyword_error", "p_no_keyword_route")
-    builder.add_edge("p_no_keyword_route", END)
     builder.add_edge("p_chat", END)
     builder.add_edge("p_chat_with_documents", END)
 

--- a/redbox-core/redbox/models/chat.py
+++ b/redbox-core/redbox/models/chat.py
@@ -69,7 +69,6 @@ class ChatRoute(StrEnum):
     chat = "chat"
     chat_with_docs = "chat/documents"
     chat_with_docs_map_reduce = "chat/documents/large"
-    error_no_keyword = "error/no-keyword"
 
 
 class ChatResponse(BaseModel):

--- a/redbox-core/redbox/models/settings.py
+++ b/redbox-core/redbox/models/settings.py
@@ -109,7 +109,6 @@ class Settings(BaseSettings):
 
     response_no_doc_available: str = "No available data for selected files. They may need to be removed and added again"
     response_max_content_exceeded: str = "Max content exceeded. Try smaller or fewer documents"
-    response_no_such_keyword: str = "That keyword isn't recognised"
 
     object_store: str = "minio"
 

--- a/redbox-core/tests/graph/test_app.py
+++ b/redbox-core/tests/graph/test_app.py
@@ -122,18 +122,30 @@ TEST_CASES = [
             test_id="Search",
         ),
         generate_test_cases(
+            query=RedboxQuery(question="@nosuchkeyword What is AI?", s3_keys=[], user_uuid=uuid4(), chat_history=[]),
+            test_data=[
+                RedboxTestData(
+                    10,
+                    1000,
+                    expected_llm_response=["Testing Response 1"],
+                    expected_route=ChatRoute.chat,
+                ),
+            ],
+            test_id="No Such Keyword",
+        ),
+        generate_test_cases(
             query=RedboxQuery(
                 question="@nosuchkeyword What is AI?", s3_keys=["s3_key"], user_uuid=uuid4(), chat_history=[]
             ),
             test_data=[
                 RedboxTestData(
-                    2,
-                    200_000,
-                    expected_llm_response=[Settings().response_no_such_keyword],
-                    expected_route=ChatRoute.error_no_keyword,
+                    1,
+                    50_000,
+                    expected_llm_response=["Testing Response 1"],
+                    expected_route=ChatRoute.chat_with_docs,
                 ),
             ],
-            test_id="No Such Keyword",
+            test_id="No Such Keyword with docs",
         ),
     ]
     for test_case in generated_cases


### PR DESCRIPTION
## Context
Users are reporting confusing 'No such keyword' errors when they have used chat messages with emails in.

## Changes proposed in this pull request
Remove the 'No such keyword' error and return a default route when users type an unexpected keyword. See discussion here: https://i-dot-ai.slack.com/archives/C05D67P6M34/p1725346351581039

![ab1084b9-ee7f-4085-a537-248a04d640dc](https://github.com/user-attachments/assets/df57c692-910e-4a8b-88f0-de24e7a90454)


## Guidance to review
Does this work as expected?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
