### PR TITLE
Use versioned terraform modules (alb, waf, ecs)

### DIFF
--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -56,11 +56,13 @@ resource "aws_secretsmanager_secret_version" "django-app-json-secret" {
 
 
 module "django-app" {
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  #source                    = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
+  source                     = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v1.0.0-ecs"
   memory                     = 4096
   cpu                        = 2048
   create_listener            = true
   create_networking          = true
-  source                     = "../../../i-ai-core-infrastructure//modules/ecs"
   name                       = "${local.name}-django-app"
   image_tag                  = var.image_tag
   ecr_repository_uri         = "${var.ecr_repository_uri}/${var.project_name}-django-app"
@@ -68,7 +70,7 @@ module "django-app" {
   ecs_cluster_name           = module.cluster.ecs_cluster_name
   autoscaling_minimum_target = 1
   autoscaling_maximum_target = 10
-  health_check               = {
+  health_check = {
     healthy_threshold   = 3
     unhealthy_threshold = 3
     accepted_response   = "200"
@@ -91,12 +93,14 @@ module "django-app" {
 
 
 module "unstructured" {
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  #source                       = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
+  source                        = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v1.0.0-ecs"
   service_discovery_service_arn = aws_service_discovery_service.unstructured_service_discovery_service.arn
   memory                        = 4096
   cpu                           = 2048
   create_listener               = false
   create_networking             = false
-  source                        = "../../../i-ai-core-infrastructure//modules/ecs"
   name                          = "${local.name}-unstructured"
   image_tag                     = "latest"
   ecr_repository_uri            = "quay.io/unstructured-io/unstructured-api"
@@ -104,7 +108,7 @@ module "unstructured" {
   ecs_cluster_name              = module.cluster.ecs_cluster_name
   autoscaling_minimum_target    = 1
   autoscaling_maximum_target    = 1
-  health_check                  = {
+  health_check = {
     healthy_threshold   = 3
     unhealthy_threshold = 3
     accepted_response   = "200"
@@ -124,12 +128,14 @@ module "unstructured" {
 
 
 module "worker" {
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  #source                      = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
+  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v1.0.0-ecs"
   command                      = ["venv/bin/django-admin", "qcluster"]
   memory                       = 6144
   cpu                          = 2048
   create_listener              = false
   create_networking            = false
-  source                       = "../../../i-ai-core-infrastructure//modules/ecs"
   name                         = "${local.name}-worker"
   image_tag                    = var.image_tag
   ecr_repository_uri           = "${var.ecr_repository_uri}/${var.project_name}-django-app"

--- a/infrastructure/aws/load_balancer.tf
+++ b/infrastructure/aws/load_balancer.tf
@@ -1,5 +1,7 @@
 module "load_balancer" {
-  source          = "../../../i-ai-core-infrastructure/modules/load_balancer"
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  #source         = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/load_balancer" # For testing local changes
+  source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/load_balancer?ref=v1.0.0-load_balancer"
   name            = local.name
   account_id      = var.account_id
   vpc_id          = data.terraform_remote_state.vpc.outputs.vpc_id
@@ -12,7 +14,9 @@ module "load_balancer" {
 
 
 module "waf" {
-  source         = "../../../i-ai-core-infrastructure/modules/waf"
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  #source         = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/waf" # For testing local changes
+  source         = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/waf?ref=v1.0.0-waf"
   name           = local.name
   ip_set         = concat(var.internal_ips, var.developer_ips, var.external_ips)
   scope          = var.scope


### PR DESCRIPTION
## Context

Use versioned terraform modules from git (alb, waf, ecs)

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
