### PR TITLE
Hide the LLM selector for now

### DIFF
--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -61,6 +61,9 @@ body:has(.iai-environment-warning) main:has(.iai-chat-input) {
     top: 6.5rem;
   }
   .iai-panel__scrollable {
+    max-height: calc(50vh - 12rem);
+  }
+  main:has(#llm-selector) .iai-panel__scrollable {
     max-height: calc(50vh - 15rem);
   }
 }

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -65,6 +65,7 @@
           </fieldset>
         </document-selector>
 
+        {# Temporarily hiding the LLM selector
         <div class="iai-panel govuk-!-margin-top-5 govuk-!-padding-top-3">
           <label class="govuk-body-s govuk-!-font-weight-bold" for="llm-selector">Model</label>
           <select id="llm-selector" name="llm" class="govuk-select govuk-!-margin-top-1">
@@ -73,6 +74,7 @@
             {% endfor %}
           </select>
         </div>
+        #}
 
       </div>
     </div>

--- a/redbox-core/redbox/chains/ingest.py
+++ b/redbox-core/redbox/chains/ingest.py
@@ -3,7 +3,6 @@ import logging
 from io import BytesIO
 from functools import partial
 
-from annotated_types import doc
 from langchain.vectorstores import VectorStore
 from langchain_core.documents.base import Document
 from langchain_core.runnables import RunnableLambda, chain, Runnable

--- a/redbox-core/redbox/loader/ingester.py
+++ b/redbox-core/redbox/loader/ingester.py
@@ -49,7 +49,7 @@ def ingest_file(file_name: str) -> str | None:
             env=env,
             min_chunk_size=env.worker_ingest_min_chunk_size,
             max_chunk_size=env.worker_ingest_max_chunk_size,
-            overlap_chars=0
+            overlap_chars=0,
         ),
         s3_client=env.s3_client(),
         vectorstore=get_elasticsearch_store(es, es_index_name),
@@ -62,7 +62,7 @@ def ingest_file(file_name: str) -> str | None:
             env=env,
             min_chunk_size=env.worker_ingest_largest_chunk_size,
             max_chunk_size=env.worker_ingest_largest_chunk_size,
-            overlap_chars=env.worker_ingest_largest_chunk_overlap
+            overlap_chars=env.worker_ingest_largest_chunk_overlap,
         ),
         s3_client=env.s3_client(),
         vectorstore=get_elasticsearch_store_without_embeddings(es, es_index_name),

--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -21,7 +21,15 @@ else:
 class UnstructuredChunkLoader:
     """Load, partition and chunk a document using local unstructured library"""
 
-    def __init__(self, chunk_resolution: ChunkResolution, env: Settings, min_chunk_size: int, max_chunk_size: int, overlap_chars: int = 0, overlap_all_chunks: bool = True):
+    def __init__(
+        self,
+        chunk_resolution: ChunkResolution,
+        env: Settings,
+        min_chunk_size: int,
+        max_chunk_size: int,
+        overlap_chars: int = 0,
+        overlap_all_chunks: bool = True,
+    ):
         self.chunk_resolution = chunk_resolution
         self.env = env
         self._min_chunk_size = min_chunk_size

--- a/redbox-core/tests/test_ingest.py
+++ b/redbox-core/tests/test_ingest.py
@@ -47,9 +47,7 @@ def make_file_query(file_name: str, resolution: ChunkResolution | None = None) -
 
 
 @patch("redbox.loader.loaders.requests.post")
-def test_document_loader(
-    mock_post: MagicMock, s3_client: S3Client, env: Settings
-):
+def test_document_loader(mock_post: MagicMock, s3_client: S3Client, env: Settings):
     """
     Given that I have written a text File to s3
     When I call document_loader
@@ -75,7 +73,7 @@ def test_document_loader(
         chunk_resolution=ChunkResolution.normal,
         env=env,
         min_chunk_size=env.worker_ingest_min_chunk_size,
-        max_chunk_size=env.worker_ingest_max_chunk_size
+        max_chunk_size=env.worker_ingest_max_chunk_size,
     )
 
     # Upload file and and call
@@ -130,7 +128,7 @@ def test_ingest_from_loader(
         chunk_resolution=resolution,
         env=env,
         min_chunk_size=env.worker_ingest_min_chunk_size,
-        max_chunk_size=env.worker_ingest_max_chunk_size
+        max_chunk_size=env.worker_ingest_max_chunk_size,
     )
 
     # Mock embeddings
@@ -138,9 +136,7 @@ def test_ingest_from_loader(
 
     # Upload file and call
     file_name = file_to_s3(filename="html/example.html", s3_client=s3_client, env=env)
-    ingest_chain = ingest_from_loader(
-        loader=loader, s3_client=s3_client, vectorstore=es_vector_store, env=env
-    )
+    ingest_chain = ingest_from_loader(loader=loader, s3_client=s3_client, vectorstore=es_vector_store, env=env)
 
     _ = ingest_chain.invoke(file_name)
 

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -335,6 +335,10 @@ class ChatsPage(SignedInBasePage):
         return "Chats - Redbox"
 
     @property
+    def selected_llm(self) -> str:
+        return self.page.locator("#llm-selector").input_value()
+
+    @property
     def write_message(self) -> str:
         return self.page.locator("#message").input_value()
 

--- a/tests/test_journey.py
+++ b/tests/test_journey.py
@@ -74,6 +74,8 @@ def test_user_journey(page: Page, email_address: str):
     logger.debug("page: %s", chats_page)
     latest_chat_response = chats_page.wait_for_latest_message()
     assert latest_chat_response.text
+    # Commented out until we make this visible
+    # assert chats_page.selected_llm == "gpt-4o"
 
     # Give user feedback
     chats_page.feedback_stars = 2


### PR DESCRIPTION
## Context

It's been decided to hide the LLM selector for now


## Changes proposed in this pull request

* Comment out HTML
* Update CSS to update automatically based on whether the LLM Selector is present or not
* Bonus: Add an integration test for when we do add it back in (commented out for now)
* Bonus 2: Linting - automated updates to 4 files


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
