### PR TITLE
fix/ Remove worker from CI docker build & tagging process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ PREV_IMAGE_TAG=$$(git rev-parse HEAD~1)
 IMAGE_TAG=$$(git rev-parse HEAD)
 
 tf_build_args=-var "image_tag=$(IMAGE_TAG)"
-DOCKER_SERVICES=$$(docker compose config --services | grep -v mlflow)
+DOCKER_SERVICES=$$(docker compose config --services | grep -Ev 'mlflow|worker')
 
 AUTO_APPLY_RESOURCES = module.django-app.aws_ecs_task_definition.aws-ecs-task \
                        module.django-app.aws_ecs_service.aws-ecs-service \

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ docker_push:
 
 .PHONY: docker_update_tag
 docker_update_tag:
-	for service in django-app worker; do \
+	for service in django-app; do \
 		MANIFEST=$$(aws ecr batch-get-image --repository-name $(ECR_REPO_NAME)-$$service --image-ids imageTag=$(IMAGE_TAG) --query 'images[].imageManifest' --output text) ; \
 		aws ecr put-image --repository-name $(ECR_REPO_NAME)-$$service --image-tag $(tag) --image-manifest "$$MANIFEST" ; \
 	done


### PR DESCRIPTION
## Context

Omits worker from the build process. Functionality is now inside the django-app, so this image is no longer required for deployment.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
