### PR TITLE
Filter out /admin from Sentry

### DIFF
--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -2,6 +2,7 @@
 import os
 import socket
 from pathlib import Path
+from urllib.parse import urlparse
 
 import environ
 import sentry_sdk
@@ -243,6 +244,14 @@ else:
     ALLOWED_HOSTS = [LOCALHOST, *ENVIRONMENT.hosts]
 
 if not ENVIRONMENT.is_local:
+
+    def filter_transactions(event):
+        url_string = event["request"]["url"]
+        parsed_url = urlparse(url_string)
+        if parsed_url.path.startswith("/admin"):
+            return None
+        return event
+
     SENTRY_DSN = env.str("SENTRY_DSN", None)
     SENTRY_ENVIRONMENT = env.str("SENTRY_ENVIRONMENT", None)
     if SENTRY_DSN and SENTRY_ENVIRONMENT:
@@ -255,6 +264,7 @@ if not ENVIRONMENT.is_local:
             send_default_pii=False,
             traces_sample_rate=1.0,
             profiles_sample_rate=0.0,
+            before_send_transaction=filter_transactions,
         )
 SENTRY_REPORT_TO_ENDPOINT = URL(env.str("SENTRY_REPORT_TO_ENDPOINT", "")) or None
 


### PR DESCRIPTION
## Context

We (probably) don't need Sentry to run on the Django Admin pages. We're getting a lot of errors around the use of jQuery and inline styles that would be a disproportionate amount of work to fix. This will also make managing "real" errors easier to discover and manage in Sentry.


## Changes proposed in this pull request

* Filter out all admin pages


## Notes

* This hasn't been properly tested yet - we can monitor this once deployed
* Does this sound like a sensible thing to do?
* Does the code look sensible?


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
