### PR TITLE
feature/allow-jpg

### DIFF
--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -48,7 +48,7 @@ APPROVED_FILE_EXTENSIONS = [
     ".bmp",
     ".jpeg",
     ".png",
-    ".jpeg",
+    ".jpg",
 ]
 MAX_FILE_SIZE = 209715200  # 200 MB or 200 * 1024 * 1024
 
@@ -123,7 +123,7 @@ class UploadView(View):
             errors.append("File has no name")
         else:
             file_extension = Path(uploaded_file.name).suffix
-            if file_extension not in APPROVED_FILE_EXTENSIONS:
+            if file_extension.lower() not in APPROVED_FILE_EXTENSIONS:
                 errors.append(f"Error with {uploaded_file.name}: File type {file_extension} not supported")
 
         if not uploaded_file.content_type:


### PR DESCRIPTION
## Context

As a user i want to be able to upload images with extensions in upper case and `.jpg` rather than `jpeg` which unstructured supports equally

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
