### PR TITLE
Feature/plausible events

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/canned-prompts.js
+++ b/django_app/frontend/src/js/web-components/chats/canned-prompts.js
@@ -5,15 +5,15 @@ class CannedPrompts extends HTMLElement {
     this.innerHTML = `
         <h3 class="chat-options__heading govuk-heading-m">What would you like to ask your Redbox?</h3>
         <div class="chat-options__options">
-            <button class="chat-options__option chat-options__option_agenda" type="button">
+            <button class="chat-options__option chat-options__option_agenda plausible-event-name--canned+prompt+draft+meeting+agenda" type="button">
                 <img src="/static/icons/icon_square_doc.svg" alt=""/>
                 Draft an agenda for a team meeting
             </button>
-            <button class="chat-options__option chat-options__option_objectives" type="button">
+            <button class="chat-options__option chat-options__option_objectives plausible-event-name--canned+prompt+set+work+objectives" type="button">
                 <img src="/static/icons/archery.svg" alt=""/>
                 Help me set my work objectives
             </button>
-            <button class="chat-options__option chat-options__option_ps_role" type="button">
+            <button class="chat-options__option chat-options__option_ps_role plausible-event-name--canned+prompt+describe+role+permanent+secretary" type="button">
                 <img src="/static/icons/person.svg" alt=""/>
                 Describe the role of a Permanent Secretary
             </button>

--- a/django_app/frontend/src/js/web-components/chats/chat-controller.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-controller.js
@@ -52,6 +52,25 @@ class ChatController extends HTMLElement {
         feedbackButtons.dataset.status = "";
       }
       textArea.value = "";
+
+      // if a route has been intentionally specified by a user, send an event to Plausible
+      (() => {
+        let plausible = /** @type {any} */ (window).plausible;
+        if (typeof plausible === "undefined") {
+          return;
+        }
+        if (userText.includes("@chat")) {
+          plausible("User-specified-route", { props: { route: "@chat" } });
+        }
+        if (userText.includes("@chat/documents")) {
+          plausible("User-specified-route", {
+            props: { route: "@chat/documents" },
+          });
+        }
+        if (userText.includes("@search")) {
+          plausible("User-specified-route", { props: { route: "@search" } });
+        }
+      })();
     });
 
     document.body.addEventListener("selected-docs-change", (evt) => {

--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -2,6 +2,31 @@
 
 import "../loading-message.js";
 
+// Send Plausible data on tool-tip hover
+/**
+ *
+ * @param {Event} evt
+ */
+const sendTooltipViewEvent = (evt) => {
+  let plausible = /** @type {any} */ (window).plausible;
+  if (typeof plausible !== "undefined") {
+    plausible("Route-tooltip-view");
+  }
+  // cancel event listener so events only get sent once
+  let targetElement = /** @type{HTMLElement | null | undefined} */ (evt.target);
+  if (targetElement?.nodeName !== "TOOL-TIP") {
+    targetElement = targetElement?.closest("tool-tip");
+  }
+  targetElement?.removeEventListener("mouseover", sendTooltipViewEvent);
+};
+// Do this for any SSR tool-tips on the page
+(() => {
+  const tooltips = document.querySelectorAll("tool-tip");
+  tooltips.forEach((tooltip) => {
+    tooltip.addEventListener("mouseover", sendTooltipViewEvent);
+  });
+})();
+
 class ChatMessage extends HTMLElement {
   constructor() {
     super();
@@ -52,7 +77,12 @@ class ChatMessage extends HTMLElement {
       document.querySelector("#template-route-display")
     );
     const routeClone = document.importNode(routeTemplate.content, true);
+
     this.querySelector(".iai-chat-bubble__header")?.appendChild(routeClone);
+    this.querySelector("tool-tip")?.addEventListener(
+      "mouseover",
+      sendTooltipViewEvent
+    );
   }
 
   /**

--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -31,6 +31,7 @@ class ChatMessage extends HTMLElement {
   constructor() {
     super();
     this.programmaticScroll = false;
+    this.plausibleRouteDataSent = false;
   }
 
   connectedCallback() {
@@ -198,8 +199,9 @@ class ChatMessage extends HTMLElement {
 
         // send route to Plausible
         let plausible = /** @type {any} */ (window).plausible;
-        if (typeof plausible !== "undefined") {
+        if (typeof plausible !== "undefined" && !this.plausibleRouteDataSent) {
           plausible("Chat-message-route", { props: { route: response.data } });
+          this.plausibleRouteDataSent = true;
         }
       } else if (response.type === "end") {
         sourcesContainer.showCitations(response.data.message_id);

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -20,7 +20,6 @@
 
   {% if environment | lower in ["dev", "preprod"] %}
     <script defer
-    event-environment="{{environment}}"
     data-domain="redbox-dev.ai.cabinetoffice.gov.uk" src="https://plausible.io/js/script.pageview-props.tagged-events.outbound-links.file-downloads.local.js"></script>
   {% elif environment | lower == "prod" %}
     <script defer


### PR DESCRIPTION
## Context

We want to collect more data in Plausible so we can make informed decisions. Details in Jira ticket: https://technologyprogramme.atlassian.net/browse/REDBOX-674


## Changes proposed in this pull request

* Collect the following events in Plausible ("Chat-message-route" already existed, the rest are new):
![image](https://github.com/user-attachments/assets/5e3292f2-2571-44e3-bb5e-ca241c83a8de)

* "Chat-message-route" and "User-specified-route" can be clicked into to find details on the routes taken

* Get Plausible dev site working (mostly settings changes in Plausible, not much has changed in terms of code)
* Fix issue where "Chat-message-route events" were being sent twice per message


## Guidance to review

If you would like to see it working, manually and temporarily add Plausible to the page. Then see the Fetch/XHR events in the network tab. It has been tested though, as the above screenshot shows, so this isn't necessarily unless you'd like to.


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
