### PR TITLE
Added additional vscode tasks to create and signin users

### DIFF
--- a/django_app/.vscode/tasks.json
+++ b/django_app/.vscode/tasks.json
@@ -23,6 +23,40 @@
                 "panel": "new"
             },
             "problemMatcher": []
+        },
+        {
+            "label": "Create Local User",
+            "type": "shell",
+            "command": "poetry run python manage.py createsuperuser  --email me@localhost --noinput",
+            "options": {
+                "env": {
+                    "MINIO_HOST": "localhost",
+                    "POSTGRES_HOST": "localhost",
+                    "UNSTRUCTURED_HOST": "localhost"
+                }
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": []
+        }
+        {
+            "label": "Get Signin Link",
+            "type": "shell",
+            "command": "poetry run python manage.py show_magiclink_url me@localhost",
+            "options": {
+                "env": {
+                    "MINIO_HOST": "localhost",
+                    "POSTGRES_HOST": "localhost",
+                    "UNSTRUCTURED_HOST": "localhost"
+                }
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": []
         }
     ]
   }


### PR DESCRIPTION
## Context

I want to be able to create and login a test user for local app development easily

## Changes proposed in this pull request

Added two new VSCode tasks: Create Local User and Get Signin Link

Create local user runs the createsuperuser command for me@localhost and sets no password
Get Signin Link gets the magiclink for me@localhost

With this a user can create the user on first setup and can generate the magic link by triggering the task in vscode, F1 -> Run Task -> Get Signin Link

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
