### PR TITLE
Working in unit tests

### DIFF
--- a/django_app/.vscode/launch.json
+++ b/django_app/.vscode/launch.json
@@ -14,7 +14,8 @@
             "env": {
                 "MINIO_HOST": "localhost",
                 "POSTGRES_HOST": "localhost",
-                "UNSTRUCTURED_HOST": "localhost"
+                "UNSTRUCTURED_HOST": "localhost",
+                "ELASTIC__HOST": "localhost"
             }
         }
         },

--- a/redbox-core/redbox/app.py
+++ b/redbox-core/redbox/app.py
@@ -39,6 +39,7 @@ class Redbox:
         route_name_callback=_default_callback,
         documents_callback=_default_callback,
         metadata_tokens_callback=_default_callback,
+        activity_event_callback=_default_callback,
     ) -> RedboxState:
         final_state = None
         async for event in self.graph.astream_events(input, version="v2"):
@@ -60,6 +61,8 @@ class Redbox:
                 await documents_callback(event["data"]["output"])
             elif kind == "on_custom_event" and event["name"] == RedboxEventType.on_metadata_generation.value:
                 await metadata_tokens_callback(event["data"])
+            elif kind == "on_custom_event" and event["name"] == RedboxEventType.activity.value:
+                await activity_event_callback(event["data"])
             elif kind == "on_chain_end" and event["name"] == "LangGraph":
                 final_state = RedboxState(**event["data"]["output"])
         return final_state

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -12,6 +12,7 @@ from redbox.graph.edges import (
 )
 from redbox.graph.nodes.processes import (
     PromptSet,
+    build_activity_log_node,
     build_error_pattern,
     build_merge_pattern,
     build_set_metadata_pattern,
@@ -29,7 +30,7 @@ from redbox.graph.nodes.processes import (
     clear_documents_process,
 )
 from redbox.graph.nodes.sends import build_document_chunk_send, build_document_group_send
-from redbox.models.graph import ROUTABLE_KEYWORDS
+from redbox.models.graph import ROUTABLE_KEYWORDS, RedboxActivityEvent
 
 
 # Subgraphs
@@ -154,6 +155,8 @@ def get_chat_with_documents_graph(
         "p_retrieve_all_chunks", build_retrieve_pattern(retriever=all_chunks_retriever, final_source_chain=True)
     )
 
+    builder.add_node("p_activity_log_tool_decision", build_activity_log_node(lambda state: RedboxActivityEvent(message=f"Using _{state["route_name"]}_")))
+
     # Decisions
     builder.add_node("d_request_handler_from_total_tokens", empty_process)
     builder.add_node("d_single_doc_summaries_bigger_than_context", empty_process)
@@ -177,8 +180,9 @@ def get_chat_with_documents_graph(
             "pass": "p_set_chat_docs_route",
         },
     )
+    builder.add_edge("p_answer_or_decide_route", "p_activity_log_tool_decision")
     builder.add_conditional_edges(
-        "p_answer_or_decide_route",
+        "p_activity_log_tool_decision",
         lambda state: state.get("route_name"),
         {
             ChatRoute.search: END,

--- a/redbox-core/redbox/models/graph.py
+++ b/redbox-core/redbox/models/graph.py
@@ -1,5 +1,7 @@
 from enum import StrEnum
 
+from pydantic import BaseModel
+
 
 from redbox.models.chat import ChatRoute
 
@@ -7,7 +9,11 @@ from redbox.models.chat import ChatRoute
 class RedboxEventType(StrEnum):
     on_metadata_generation = "on_metadata_generation"
     response_tokens = "response_tokens"
+    activity = "activity"
 
+
+class RedboxActivityEvent(BaseModel):
+    message: str
 
 FINAL_RESPONSE_TAG = "response_flag"
 SOURCE_DOCUMENTS_TAG = "source_documents_flag"

--- a/redbox-core/redbox/test/data.py
+++ b/redbox-core/redbox/test/data.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from dataclasses import dataclass, field
 import datetime
 import logging
@@ -9,6 +10,7 @@ from langchain_core.retrievers import BaseRetriever
 from redbox.models.chain import RedboxQuery
 from redbox.models.chat import ChatRoute
 from redbox.models.file import ChunkMetadata, ChunkResolution
+from redbox.models.graph import RedboxActivityEvent
 
 log = logging.getLogger()
 
@@ -41,6 +43,7 @@ class RedboxTestData:
     chunk_resolution: ChunkResolution = ChunkResolution.largest
     expected_llm_response: list[str] = field(default_factory=list)
     expected_route: ChatRoute | None = None
+    expected_activity_events: Callable[[list[RedboxActivityEvent]], bool] = field(default=lambda _: True) #Function to check activity events are as expected
 
 
 class RedboxChatTestCase:

--- a/redbox-core/tests/graph/test_app.py
+++ b/redbox-core/tests/graph/test_app.py
@@ -9,6 +9,7 @@ from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from redbox.models.chain import RedboxQuery, RedboxState, RequestMetadata
 from redbox import Redbox
 from redbox.models.chat import ChatRoute, ErrorRoute
+from redbox.models.graph import RedboxActivityEvent
 from redbox.models.settings import Settings
 from redbox.test.data import (
     RedboxTestData,
@@ -25,6 +26,10 @@ LANGGRAPH_DEBUG = True
 
 SELF_ROUTE_TO_SEARCH = ["Condense self route question", "Testing Response - Search"]
 SELF_ROUTE_TO_CHAT = ["Condense self route question", "unanswerable"]
+
+def assert_number_of_events(num_of_events: int):
+    return lambda events_list: len(events_list) == num_of_events
+
 
 TEST_CASES = [
     test_case
@@ -69,6 +74,7 @@ TEST_CASES = [
                     140_000,
                     expected_llm_response=SELF_ROUTE_TO_CHAT + ["Map Step Response"] * 2 + ["Testing Response 1"],
                     expected_route=ChatRoute.chat_with_docs_map_reduce,
+                    expected_activity_events=assert_number_of_events(1)
                 ),
                 RedboxTestData(
                     4,
@@ -78,6 +84,7 @@ TEST_CASES = [
                     + ["Merge Per Document Response"] * 2
                     + ["Testing Response 1"],
                     expected_route=ChatRoute.chat_with_docs_map_reduce,
+                    expected_activity_events=assert_number_of_events(1)
                 ),
             ],
             test_id="Chat with multiple docs",
@@ -93,6 +100,8 @@ TEST_CASES = [
                     + ["Merge Per Document Response"]
                     + ["Testing Response 1"],
                     expected_route=ChatRoute.chat_with_docs_map_reduce,
+                    expected_activity_events=assert_number_of_events(1)
+
                 ),
             ],
             test_id="Chat with large doc",
@@ -105,6 +114,7 @@ TEST_CASES = [
                     200_000,
                     expected_llm_response=SELF_ROUTE_TO_SEARCH,  # + ["Condense Question", "Testing Response 1"],
                     expected_route=ChatRoute.search,
+                    expected_activity_events=assert_number_of_events(1)
                 ),
             ],
             test_id="Self Route Search large doc",
@@ -187,6 +197,7 @@ async def test_streaming(test: RedboxChatTestCase, env: Settings, mocker: Mocker
     # Define callback functions
     token_events = []
     metadata_events = []
+    activity_events = []
     route_name = None
 
     async def streaming_response_handler(tokens: str):
@@ -199,6 +210,9 @@ async def test_streaming(test: RedboxChatTestCase, env: Settings, mocker: Mocker
         nonlocal route_name
         route_name = route
 
+    async def streaming_activity_handler(activity_event: RedboxActivityEvent):
+        activity_events.append(activity_event)
+
     llm = GenericFakeChatModel(messages=iter(test_case.test_data.expected_llm_response))
 
     (mocker.patch("redbox.graph.nodes.processes.get_chat_llm", return_value=llm),)
@@ -207,6 +221,7 @@ async def test_streaming(test: RedboxChatTestCase, env: Settings, mocker: Mocker
         response_tokens_callback=streaming_response_handler,
         metadata_tokens_callback=metadata_response_handler,
         route_name_callback=streaming_route_name_handler,
+        activity_event_callback=streaming_activity_handler
     )
 
     final_state = RedboxState(response)
@@ -217,6 +232,8 @@ async def test_streaming(test: RedboxChatTestCase, env: Settings, mocker: Mocker
     if not route_name.startswith("error"):
         assert len(token_events) > 1, f"Expected tokens as a stream. Received: {token_events}"
         assert len(metadata_events) == len(test_case.test_data.expected_llm_response)
+
+    assert test_case.test_data.expected_activity_events(activity_events), f"Activity events not as expected. Received: {activity_events}"
 
     llm_response = "".join(token_events)
     number_of_selected_files = len(test_case.query.s3_keys)


### PR DESCRIPTION
## Context

We want to report what Redbox is doing to users. Choices made, details about which files were read etc

## Changes proposed in this pull request

Create a new activity event type and a node to emit these as needed in the graph. These events can be emitted from inside another node as well though.

## Guidance to review

Do we want these event emitting nodes? Is there a nicer way to pull these dispatch calls into nodes?
Are we ok with the structure of the events, is just a str better? Does having a BaseModel gives us flexibility in future?


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
