### PR TITLE
Send list of user approved files to redbox

### DIFF
--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -194,6 +194,7 @@ class RedboxQuery(BaseModel):
     user_uuid: UUID = Field(description="User the chain in executing for")
     chat_history: list[ChainChatMessage] = Field(description="All previous messages in chat (excluding question)")
     ai_settings: AISettings = Field(description="User request AI settings", default_factory=AISettings)
+    permitted_s3_keys: list[str] = Field(description="List of permitted files for response", default_factory=list)
 
 
 class LLMCallMetadata(BaseModel):


### PR DESCRIPTION
## Context

Since moving the chunk user information out of Elastic, Redbox core doesn't know which documents belong to which user. This creates problems when no document is selected and Redbox chooses to search all documents, instead of just those for the user. 

## Changes proposed in this pull request

Send a list of permitted files (which is all files belonging to the user) as part of the Request from Django. This is an interim fix pending further discussion about our approach.

#1057 uses the permitted files in the existing graph.

## Guidance to review

Does this look reasonable? Could we clarify the tests?

## Things to check

- ~[ ] I have added any new ENV vars in all deployed environments~
- [x] I have tested any code added or changed
- [x] I have run integration tests
