### PR TITLE
Tidy up deletion code

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -295,7 +295,7 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     @override
     def delete(self, using=None, keep_parents=False):
         #  Needed to make sure no orphaned files remain in the storage
-        self.original_file.storage.delete(self.original_file.name)
+        self.delete_from_s3()
         super().delete()
 
     def delete_from_s3(self):
@@ -363,7 +363,12 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
 
     @property
     def unique_name(self) -> str:
-        # Name used by core-api
+        # Name used when processing files that exist in S3
+        if self.status not in [StatusEnum.processing, StatusEnum.complete]:
+            logger.exception(
+                "Attempt to access unique_name for inaccessible file %s with status %s", self.pk, self.status
+            )
+            raise ValueError
         return self.original_file.name
 
     def get_status_text(self) -> str:

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -364,10 +364,8 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     @property
     def unique_name(self) -> str:
         # Name used when processing files that exist in S3
-        if self.status not in [StatusEnum.processing, StatusEnum.complete]:
-            logger.exception(
-                "Attempt to access unique_name for inaccessible file %s with status %s", self.pk, self.status
-            )
+        if self.status in INACTIVE_STATUSES:
+            logger.exception("Attempt to access unique_name for inactive file %s with status %s", self.pk, self.status)
             raise ValueError
         return self.original_file.name
 

--- a/django_app/tests/test_models.py
+++ b/django_app/tests/test_models.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 
-from redbox_app.redbox_core.models import File, StatusEnum
+from redbox_app.redbox_core.models import File, InactiveFileError, StatusEnum, User
 
 
 @pytest.mark.django_db()
@@ -29,3 +29,46 @@ def test_file_model_last_referenced(peter_rabbit, s3_client):  # noqa: ARG001
     new_file.last_referenced = new_date
     new_file.save()
     assert new_file.last_referenced == new_date
+
+
+@pytest.mark.parametrize(
+    ("status"),
+    [
+        StatusEnum.complete,
+        StatusEnum.processing,
+    ],
+)
+@pytest.mark.django_db()
+def test_file_model_unique_name(status: str, peter_rabbit: User, s3_client):  # noqa: ARG001
+    mock_file = SimpleUploadedFile("test.txt", b"these are the file contents")
+
+    new_file = File.objects.create(
+        status=status,
+        original_file=mock_file,
+        user=peter_rabbit,
+        original_file_name="test.txt",
+    )
+
+    assert new_file.unique_name  # Check new name can be retrieved without error
+
+
+@pytest.mark.parametrize(
+    ("status"),
+    [
+        StatusEnum.deleted,
+        StatusEnum.errored,
+    ],
+)
+@pytest.mark.django_db()
+def test_file_model_unique_name_error_states(status: str, peter_rabbit: User, s3_client):  # noqa: ARG001
+    mock_file = SimpleUploadedFile("test.txt", b"these are the file contents")
+
+    new_file = File.objects.create(
+        status=status,
+        original_file=mock_file,
+        user=peter_rabbit,
+        original_file_name="test.txt",
+    )
+
+    with pytest.raises(InactiveFileError, match="is inactive, status is"):
+        assert new_file.unique_name


### PR DESCRIPTION
## Context
While looking into issues with file naming and deletion, I found some duplicate code for deletion and a lack of error handling around unique_name (which should only be accessed for files uploaded to S3) - I have improved the error handling around this.

## Changes proposed in this pull request
Use existing `delete_from_s3` method for file deletion. 
Add Errors around using `unique_name` for deleted or errored files, with more explicit error messages. 

## Guidance to review
Are the error messages clear?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
