### PR TITLE
Extend ingest to bring in more file metadata

### DIFF
--- a/redbox-core/redbox/chains/ingest.py
+++ b/redbox-core/redbox/chains/ingest.py
@@ -1,15 +1,14 @@
-from typing import TYPE_CHECKING
 import logging
-from io import BytesIO
 from functools import partial
+from io import BytesIO
+from typing import TYPE_CHECKING
 
 from langchain.vectorstores import VectorStore
 from langchain_core.documents.base import Document
-from langchain_core.runnables import RunnableLambda, chain, Runnable
+from langchain_core.runnables import Runnable, RunnableLambda, chain
 
 from redbox.loader.loaders import UnstructuredChunkLoader
 from redbox.models.settings import Settings
-
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
@@ -26,17 +25,26 @@ def log_chunks(chunks: list[Document]):
     return chunks
 
 
-def document_loader(document_loader: UnstructuredChunkLoader, s3_client: S3Client, env: Settings) -> Runnable:
+def document_loader(
+    document_loader: UnstructuredChunkLoader, s3_client: S3Client, env: Settings
+) -> Runnable:
     @chain
     def wrapped(file_name: str):
-        file_bytes = s3_client.get_object(Bucket=env.bucket_name, Key=file_name)["Body"].read()
-        return document_loader.lazy_load(file_name=file_name, file_bytes=BytesIO(file_bytes))
+        file_bytes = s3_client.get_object(Bucket=env.bucket_name, Key=file_name)[
+            "Body"
+        ].read()
+        return document_loader.lazy_load(
+            file_name=file_name, file_bytes=BytesIO(file_bytes)
+        )
 
     return wrapped
 
 
 def ingest_from_loader(
-    loader: UnstructuredChunkLoader, s3_client: S3Client, vectorstore: VectorStore, env: Settings
+    loader: UnstructuredChunkLoader,
+    s3_client: S3Client,
+    vectorstore: VectorStore,
+    env: Settings,
 ) -> Runnable:
     return (
         document_loader(document_loader=loader, s3_client=s3_client, env=env)

--- a/redbox-core/redbox/loader/base.py
+++ b/redbox-core/redbox/loader/base.py
@@ -1,0 +1,17 @@
+from io import BytesIO
+
+from langchain_core.document_loaders import BaseLoader
+
+from redbox.models.settings import Settings
+
+
+class BaseRedboxFileLoader(BaseLoader):
+    def __init__(self, file_name: str, file_bytes: BytesIO, env: Settings) -> None:
+        """Initialize the loader with a file path.
+
+        Args:
+            file: The Redbox File to load
+        """
+        self.file_name = file_name
+        self.file_bytes = file_bytes
+        self.env = env

--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -1,13 +1,23 @@
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from io import BytesIO
+from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
 import requests
+
+# import textract
 import tiktoken
 from langchain_core.documents import Document
+from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from pymediainfo import MediaInfo
 
-from redbox.models.file import ChunkResolution, ChunkMetadata
+from redbox.chains.components import get_chat_llm
+from redbox.loader.base import BaseRedboxFileLoader
+from redbox.models.chain import AISettings
+from redbox.models.file import ChunkMetadata, ChunkResolution
 from redbox.models.settings import Settings
 
 encoding = tiktoken.get_encoding("cl100k_base")
@@ -18,7 +28,7 @@ else:
     S3Client = object
 
 
-class UnstructuredChunkLoader:
+class UnstructuredChunkLoader(BaseRedboxFileLoader):
     """Load, partition and chunk a document using local unstructured library"""
 
     def __init__(
@@ -37,14 +47,119 @@ class UnstructuredChunkLoader:
         self._overlap_chars = overlap_chars
         self._overlap_all_chunks = overlap_all_chunks
 
+    def detect_encoding_and_extract_text(
+        file_name: str, file_bytes: BytesIO, tokens: int
+    ) -> str:
+        """Detect encoding and extract first n tokens from any document type."""
+        encoding = tiktoken.encoding_for_model("gpt-4")
+        file_path = Path(file_name)
+
+        try:
+            with NamedTemporaryFile(
+                prefix=file_path.stem, suffix=file_path.suffix, delete=True, mode="wb"
+            ) as temp_file:
+                temp_file.write(file_bytes.getvalue())
+                temp_file.flush()
+            #     text = textract.process(temp_file.name).decode("utf-8")
+
+            # first_n = encoding.encode(text)[:tokens]
+
+            # return encoding.decode(first_n)
+            return True
+        except Exception as e:
+            raise ValueError(f"An error occurred while extracting text: {str(e)}")
+
+    def extract_hardcoded_metadata(
+        file_name: str, file_bytes: BytesIO
+    ) -> dict[str, str]:
+        file_path = Path(file_name)
+
+        try:
+            with NamedTemporaryFile(
+                prefix=file_path.stem, suffix=file_path.suffix, delete=True, mode="wb"
+            ) as temp_file:
+                temp_file.write(file_bytes.getvalue())
+                temp_file.flush()
+                media_info = MediaInfo.parse(temp_file.name)
+                metadata = {}
+
+                for track in media_info.tracks:
+                    if track.track_type == "General":
+                        metadata["title"] = (
+                            track.title if track.title else file_path.name
+                        )
+                        metadata["creator"] = (
+                            track.performer
+                            if track.performer
+                            else track.album_performer
+                        )
+                        metadata["subject"] = track.track_type
+                        metadata["description"] = track.comment
+                        metadata["publisher"] = track.publisher
+                        metadata["date"] = track.recorded_date
+                        metadata["language"] = track.language
+                        metadata["format"] = track.format
+
+                return metadata
+        except Exception as e:
+            raise ValueError(f"An error occurred while extracting text: {str(e)}")
+
+    def get_metadata(self) -> dict[str, Any]:
+        LLM = get_chat_llm(env=self.env, ai_settings=AISettings)
+        metadata_chain = (
+            ChatPromptTemplate.from_messages(
+                [
+                    (
+                        "system",
+                        "You are an SEO specialist that must optimise the metadata of a document to make it as discoverable as possible. You are about to be given the first 1_000 tokens of a document and any hard-coded file metadata that can be recovered from it. Create SEO-optimised metadata for this document in the structured data markup (JSON-LD) standard. You must include at least the 'name', 'description' and 'keywords' properties but otherwise use your expertise to make the document as easy to search for as possible. Return only the JSON-LD: \n\n",
+                    ),
+                    (
+                        "user",
+                        (
+                            "<metadata>\n"
+                            "{metadata}\n"
+                            "</metadata>\n\n"
+                            "<document_sample>\n"
+                            "{page_content}"
+                            "</document_sample>"
+                        ),
+                    ),
+                ]
+            )
+            | LLM
+            | JsonOutputParser()
+        )
+
+        return metadata_chain.invoke(
+            {
+                "page_content": self.detect_encoding_and_extract_text(
+                    file_name=self.file_name, file_bytes=self.file_bytes, tokens=1_000
+                ),
+                "metadata": self.extract_hardcoded_metadata(
+                    file_name=self.file_name,
+                    file_bytes=self.file_bytes,
+                ),
+            }
+        )
+
+    def coerce_to_string_list(input_data: str | list[Any]) -> list[str]:
+        if isinstance(input_data, str):
+            return [item.strip() for item in input_data.split(",")]
+        elif isinstance(input_data, list):
+            return [str(i) for i in input_data]
+        else:
+            raise ValueError("Input must be either a list or a string.")
+
     def lazy_load(self, file_name: str, file_bytes: BytesIO) -> Iterator[Document]:
         """A lazy loader that reads a file line by line.
 
         When you're implementing lazy load methods, you should use a generator
         to yield documents one by one.
         """
+        metadata = self.get_metadata()
 
         url = f"http://{self.env.unstructured_host}:8000/general/v0/general"
+
         files = {
             "files": (file_name, file_bytes),
         }
@@ -79,5 +194,9 @@ class UnstructuredChunkLoader:
                     created_datetime=datetime.now(UTC),
                     token_count=len(encoding.encode(raw_chunk["text"])),
                     chunk_resolution=self.chunk_resolution,
+                    name=metadata.get("name", self.file_name),
+                    description=metadata.get("description", "None"),
+                    keywords=self.coerce_to_string_list(metadata.get("keywords", [])),
+                    # prepositions=preposition_chain.invoke({"page_content": raw_chunk["text"]}),
                 ).model_dump(),
             )

--- a/redbox-core/redbox/models/file.py
+++ b/redbox-core/redbox/models/file.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import datetime
 from enum import StrEnum
 from uuid import UUID, uuid4
-import datetime
 
 from pydantic import BaseModel, Field
 
@@ -28,3 +28,6 @@ class ChunkMetadata(BaseModel):
     created_datetime: datetime.datetime = datetime.datetime.now(datetime.UTC)
     token_count: int
     chunk_resolution: ChunkResolution = ChunkResolution.normal
+    name: str
+    description: str | None = None
+    keywords: list | None = None


### PR DESCRIPTION
## Context
We currently don’t ingest much metadata with our files. This metadata will be important for agentic RAG as the LLM can filter based on this metadata and retrieve better data.
Update ingest to include metadata as per the [agentic spike](https://github.com/i-dot-ai/redbox/blob/spike/rag/notebooks/rag2.ipynb)

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Update ingest to include additional metadata (LLM generated) i.e. name, description, and keywords
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
