### PR TITLE
feat: integrate google analytics where uktrade is the repo owner

### DIFF
--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -95,6 +95,9 @@ def environment(**options):
             "to_user_timezone": to_user_timezone,
             "environment": settings.ENVIRONMENT.value,
             "security": settings.MAX_SECURITY_CLASSIFICATION.value,
+            "repo_owner": settings.REPO_OWNER,
+            "analytics_tag": settings.ANALYTICS_TAG,
+            "analytics_link": settings.ANALYTICS_LINK,
         }
     )
     return env

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -355,3 +355,7 @@ Q_CLUSTER = {
 }
 
 UNSTRUCTURED_HOST = env.str("UNSTRUCTURED_HOST")
+
+REPO_OWNER = env.str("REPO_OWNER", "i-dot-ai")
+ANALYTICS_TAG = env.str("ANALYTICS_TAG", " ")
+ANALYTICS_LINK = env.str("ANALYTICS_LINK", " ")

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -26,6 +26,18 @@
     data-domain="redbox.ai.cabinetoffice.gov.uk" src="https://plausible.io/js/script.pageview-props.tagged-events.outbound-links.file-downloads.js"></script>
   {% endif %}
 
+  {% if environment | lower == "prod" and repo_owner | lower == "uktrade" %}
+    <!-- Google tag (gtag.js) -->
+  <script async src="{{ analytics_link }}"></script>
+  <script> 
+  window.dataLayer = window.dataLayer || []; 
+  function gtag(){dataLayer.push(arguments);} 
+  gtag('js', new Date()); 
+
+  gtag('config', '{{ analytics_tag }}'); 
+  </script>
+  {% endif %}
+
   {# Temporarily removed due to this adding inline styles, which our CSP doesn't allow
   {% if environment | lower == "preprod" %}
     <script type="module" src="{{ static('js/posthog.js') }}"></script>


### PR DESCRIPTION
## Context

As part of DBT's ongoing task to contribute back to i.AI's redbox repo, we are using google analytics in the circumstance that the repo owner setting is set to uktrade.

