### PR TITLE
add id-token write permissions

### DIFF
--- a/.github/workflows/_cicd.yml
+++ b/.github/workflows/_cicd.yml
@@ -19,6 +19,7 @@ on:
         default: refs/heads/main
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -15,6 +15,7 @@ on:
   #     - "main"
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,7 @@ on:
       - 'main'
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,6 +17,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## Context

Another change to fix the integration with our infrastructure workflows

## Changes proposed in this pull request
Add `id-token: write` permissions

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
