### PR TITLE
feature/tests-for-graph-node-sends

### DIFF
--- a/redbox-core/redbox/graph/nodes/sends.py
+++ b/redbox-core/redbox/graph/nodes/sends.py
@@ -6,7 +6,7 @@ from redbox.models.chain import RedboxState
 
 
 def _copy_state(state: RedboxState, **updates) -> RedboxState:
-    kwargs = {k: v for k, v in state.items()} | updates
+    kwargs = dict(state) | updates
     return RedboxState(**kwargs)
 
 

--- a/redbox-core/redbox/graph/nodes/sends.py
+++ b/redbox-core/redbox/graph/nodes/sends.py
@@ -5,16 +5,18 @@ from langgraph.constants import Send
 from redbox.models.chain import RedboxState
 
 
+def _copy_state(state: RedboxState, **updates) -> RedboxState:
+    kwargs = {k: v for k, v in state.items()} | updates
+    return RedboxState(**kwargs)
+
+
 def build_document_group_send(target: str) -> Callable[[RedboxState], list[Send]]:
     """builds Sends per document-groups"""
 
     def _group_send(state: RedboxState) -> list[Send]:
         group_send_states: list[RedboxState] = [
-            RedboxState(
-                request=state["request"],
-                text=state.get("text"),
+            _copy_state(state,
                 documents={document_group_key: document_group},
-                route_name=state.get("route_name"),
             )
             for document_group_key, document_group in state["documents"].items()
         ]
@@ -28,11 +30,8 @@ def build_document_chunk_send(target: str) -> Callable[[RedboxState], list[Send]
 
     def _chunk_send(state: RedboxState) -> list[Send]:
         chunk_send_states: list[RedboxState] = [
-            RedboxState(
-                request=state["request"],
-                text=state.get("text"),
+            _copy_state(state,
                 documents={document_group_key: {document_key: document}},
-                route_name=state.get("route_name"),
             )
             for document_group_key, document_group in state["documents"].items()
             for document_key, document in document_group.items()

--- a/redbox-core/tests/graph/nodes/test_sends.py
+++ b/redbox-core/tests/graph/nodes/test_sends.py
@@ -1,0 +1,66 @@
+from uuid import uuid4
+
+from langchain_core.documents import Document
+from langgraph.constants import Send
+
+from redbox.graph.nodes.sends import build_document_group_send, build_document_chunk_send
+from redbox.models.chain import RedboxState, RedboxQuery, DocumentState
+
+
+def test_build_document_group_send():
+    target = "my-target"
+    request = RedboxQuery(question="what colour is the sky?", user_uuid=uuid4(), chat_history=[])
+    documents = DocumentState(
+        group={uuid4(): Document(page_content="Hello, world!"), uuid4(): Document(page_content="Goodbye, world!")}
+    )
+
+    document_group_send = build_document_group_send("my-target")
+    state = RedboxState(
+        request=request,
+        documents=documents,
+        text=None,
+        route_name=None,
+    )
+    actual = document_group_send(state)
+    expected = [Send(node=target, arg=state)]
+    assert expected == actual
+
+
+def test_build_document_chunk_send():
+    target = "my-target"
+    request = RedboxQuery(question="what colour is the sky?", user_uuid=uuid4(), chat_history=[])
+
+    uuid_1 = uuid4()
+    doc_1 = Document(page_content="Hello, world!")
+    uuid_2 = uuid4()
+    doc_2 = Document(page_content="Goodbye, world!")
+
+    document_chunk_send = build_document_chunk_send("my-target")
+    state = RedboxState(
+        request=request,
+        documents=DocumentState(group={uuid_1: doc_1, uuid_2: doc_2}),
+        text=None,
+        route_name=None,
+    )
+    actual = document_chunk_send(state)
+    expected = [
+        Send(
+            node=target,
+            arg=RedboxState(
+                request=request,
+                documents=DocumentState(group={uuid_1: doc_1}),
+                text=None,
+                route_name=None,
+            ),
+        ),
+        Send(
+            node=target,
+            arg=RedboxState(
+                request=request,
+                documents=DocumentState(group={uuid_2: doc_2}),
+                text=None,
+                route_name=None,
+            ),
+        ),
+    ]
+    assert expected == actual


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

1. bug fix: `route` -> `route_name`
2. tests added for `build_document_group_send` and `build_document_chunk_send`
3. remove redundant KeyValue check, this error will be raised anyway

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
