### PR TITLE
Automate adding an alias to the ElasticSearch client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ safe:  ##
 
 .PHONY: check-migrations
 check-migrations: stop  ## Check types in redbox and worker
-	docker compose up -d --wait db minio
+	docker compose up -d --wait db minio elasticsearch
 	cd django_app && poetry run python manage.py migrate
 	cd django_app && poetry run python manage.py makemigrations --check
 

--- a/django_app/redbox_app/redbox_core/management/commands/delete_es_indices.py
+++ b/django_app/redbox_app/redbox_core/management/commands/delete_es_indices.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.core.management import BaseCommand
+from django.core.management import BaseCommand, CommandError
 
 from redbox.models import Settings
 
@@ -33,6 +33,10 @@ class Command(BaseCommand):
             logger.exception("Error fetching indices", exc_info=e)
 
     def handle(self, *_args, **kwargs):
+        if not kwargs["new_index"]:
+            msg = "No new index given for alias"
+            raise CommandError(msg)
+
         chunk_indices = self.list_chunk_indices()
 
         for index in chunk_indices:

--- a/django_app/redbox_app/redbox_core/management/commands/reingest_files.py
+++ b/django_app/redbox_app/redbox_core/management/commands/reingest_files.py
@@ -15,6 +15,19 @@ env = Settings()
 es_client = env.elasticsearch_client()
 
 
+def switch_aliases(alias, new_index):
+    try:
+        response = es_client.indices.get_alias(name=alias)
+        indices_to_remove = list(response)
+    except Exception as e:
+        logger.exception("Error fetching alias", exc_info=e)
+
+    actions = [{"remove": {"index": index, "alias": alias}} for index in indices_to_remove]
+    actions.append({"add": {"index": new_index, "alias": alias}})
+
+    es_client.indices.update_aliases(body={"actions": actions})
+
+
 class Command(BaseCommand):
     help = """This is an ad-hoc command when changes to the AI pipeline (e.g. a new embedding strategy)
     mean we need to regenerate chunks for all the current files.
@@ -34,3 +47,4 @@ class Command(BaseCommand):
             async_task(
                 ingest, file.id, new_index, task_name=file.original_file.name, group="re-ingest", sync=kwargs["sync"]
             )
+        async_task(switch_aliases, env.elastic_chunk_alias, new_index, task_name="switch_aliases")

--- a/django_app/tests/management/test_commands.py
+++ b/django_app/tests/management/test_commands.py
@@ -237,3 +237,14 @@ def test_reingest_files_unstructured_fail(uploaded_file: File, requests_mock: Mo
     uploaded_file.refresh_from_db()
     assert uploaded_file.status == StatusEnum.errored
     assert uploaded_file.ingest_error == "<class 'ValueError'>: Unstructured failed to extract text for this file"
+
+
+def test_delete_es_indices_no_new_index():
+    # Given
+
+    # When
+    with pytest.raises(CommandError) as exception:
+        call_command("delete_es_indices")
+
+    # Then
+    assert str(exception.value) == "No new index given for alias"

--- a/redbox-core/redbox/models/settings.py
+++ b/redbox-core/redbox/models/settings.py
@@ -134,6 +134,11 @@ class Settings(BaseSettings):
         else:
             client = Elasticsearch(cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key)
 
+        if not client.indices.exists_alias(name=f"{self.elastic_root_index}-chunk-current"):
+            chunk_index = f"{self.elastic_root_index}-chunk"
+            client.options(ignore_status=[400]).indices.create(index=chunk_index)
+            client.indices.put_alias(index=chunk_index, name=f"{self.elastic_root_index}-chunk-current")
+
         return client.options(request_timeout=30, retry_on_timeout=True, max_retries=3)
 
     def s3_client(self):

--- a/redbox-core/tests/test_ingest.py
+++ b/redbox-core/tests/test_ingest.py
@@ -19,7 +19,7 @@ from redbox.loader.loaders import (
     coerce_to_string_list,
 )
 from redbox.models.file import ChunkResolution
-from redbox.loader.ingester import ingest_file, create_alias
+from redbox.loader.ingester import ingest_file
 from redbox.models.settings import Settings
 from redbox.retriever.queries import build_query_filter
 
@@ -215,7 +215,6 @@ def test_ingest_from_loader(
     When I call ingest_from_loader
     I Expect to see this file chunked and embedded if appropriate
     """
-    create_alias(f"{es_index}-current")
 
     # Mock call to Unstructured
     mock_response = mock_post.return_value


### PR DESCRIPTION
## Context
Recent changes in #1071 have broken the local environment for users, as redbox-core was making reference to an Elastic alias that did not exist without running the `add_es_alias` management command. 

## Changes proposed in this pull request
* Creates the chunk alias (and a default index) on the creation of the ElasticSearch client. 
* Fixes an issue with the 'delete es indices' management command that left it easy for a user to accidentally delete all chunk data from Elastic. 

## Guidance to review
Is this the right approach? Is it overkill?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
