### PR TITLE
fix bug metadata only return 3 tags

### DIFF
--- a/redbox-core/redbox/models/settings.py
+++ b/redbox-core/redbox/models/settings.py
@@ -91,8 +91,12 @@ class Settings(BaseSettings):
     worker_ingest_largest_chunk_size: int = 300_000
     worker_ingest_largest_chunk_overlap: int = 0
 
-    response_no_doc_available: str = "No available data for selected files. They may need to be removed and added again"
-    response_max_content_exceeded: str = "Max content exceeded. Try smaller or fewer documents"
+    response_no_doc_available: str = (
+        "No available data for selected files. They may need to be removed and added again"
+    )
+    response_max_content_exceeded: str = (
+        "Max content exceeded. Try smaller or fewer documents"
+    )
 
     object_store: str = "minio"
 
@@ -101,7 +105,9 @@ class Settings(BaseSettings):
 
     unstructured_host: str = "unstructured"
 
-    model_config = SettingsConfigDict(env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True)
+    model_config = SettingsConfigDict(
+        env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True
+    )
 
     ## Prompts
     metadata_prompt: tuple = (
@@ -110,10 +116,10 @@ class Settings(BaseSettings):
         "to make it as discoverable as possible. You are about to be given the first "
         "1_000 tokens of a document and any hard-coded file metadata that can be "
         "recovered from it. Create SEO-optimised metadata for this document in the "
-        "structured data markup (JSON-LD) standard. You must include at least "
-        "the 'name', 'description' and 'keywords' properties but otherwise use your "
-        "expertise to make the document as easy to search for as possible. "
-        "Return only the JSON-LD: \n\n",
+        "structured data markup (JSON-LD) standard. You must include  "
+        "the 'name', 'description' and 'keywords' properties to make the document as easy to search for as possible. "
+        "Description must be less than 100 words. and no more than 5 keywords ."
+        "Return only the JSON-LD:\n\n",
     )
 
     @lru_cache(1)
@@ -130,7 +136,9 @@ class Settings(BaseSettings):
                 basic_auth=(self.elastic.user, self.elastic.password),
             )
         else:
-            client = Elasticsearch(cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key)
+            client = Elasticsearch(
+                cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key
+            )
 
         return client.options(request_timeout=30, retry_on_timeout=True, max_retries=3)
 


### PR DESCRIPTION
## Context

Fixing bug in metadata: 

Invalid 'messages[1].content': string too long. Expected a string with maximum length 1048576, but got a string with length 1252301 instead

## Changes proposed in this pull request

Update the metadata prompt to only return 'name', 'description' and 'keywords',

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [x] ~~I have added any new ENV vars in all deployed environments~~
- [x] I have tested any code added or changed
- [x] I have run integration tests (https://github.com/i-dot-ai/redbox/actions/runs/11291983317)
