### PR TITLE
split host and port reference

### DIFF
--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -35,7 +35,7 @@ class ChatsView(View):
             messages = ChatMessage.get_messages_ordered_by_citation_priority(chat_id)
         endpoint = URL.build(
             scheme=settings.WEBSOCKET_SCHEME,
-            host=request.META["SERVER_NAME"],
+            host="localhost" if settings.ENVIRONMENT.is_test else request.META["SERVER_NAME"],
             port=int(request.META["SERVER_PORT"]),
             path=r"/ws/chat/",
         )

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -33,7 +33,12 @@ class ChatsView(View):
             if current_chat.user != request.user:
                 return redirect(reverse("chats"))
             messages = ChatMessage.get_messages_ordered_by_citation_priority(chat_id)
-        endpoint = URL.build(scheme=settings.WEBSOCKET_SCHEME, host=request.get_host(), path=r"/ws/chat/")
+        endpoint = URL.build(
+            scheme=settings.WEBSOCKET_SCHEME,
+            host=request.META["SERVER_NAME"],
+            port=int(request.META["SERVER_PORT"]),
+            path=r"/ws/chat/",
+        )
 
         completed_files, processing_files = File.get_completed_and_processing_files(request.user)
 

--- a/django_app/redbox_app/setting_enums.py
+++ b/django_app/redbox_app/setting_enums.py
@@ -2,7 +2,7 @@ import os
 from enum import StrEnum
 
 ADDITIONAL_HOSTS = os.environ.get("ADDITIONAL_HOSTS", "").split(";")
-LOCAL_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
+LOCAL_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]  # noqa: S104: Not in prod
 
 
 class Environment(StrEnum):
@@ -21,8 +21,8 @@ class Environment(StrEnum):
     def uses_minio(self) -> bool:
         return self.is_test
 
-    LOCAL = ("LOCAL", True, [*LOCAL_HOSTS, *ADDITIONAL_HOSTS])  # noqa: S104 nosec: B104: Not in prod
-    INTEGRATION = ("INTEGRATION", True, [*LOCAL_HOSTS, *ADDITIONAL_HOSTS])  # noqa: S104 nosec: B104: Not in prod
+    LOCAL = ("LOCAL", True, [*LOCAL_HOSTS, *ADDITIONAL_HOSTS])  # nosec: B104: Not in prod
+    INTEGRATION = ("INTEGRATION", True, [*LOCAL_HOSTS, *ADDITIONAL_HOSTS])  # nosec: B104: Not in prod
     DEV = ("DEV", False, ["redbox-dev.ai.cabinetoffice.gov.uk", *ADDITIONAL_HOSTS])
     PREPROD = ("PREPROD", False, ["redbox-preprod.ai.cabinetoffice.gov.uk", *ADDITIONAL_HOSTS])
     PROD = ("PROD", False, ["redbox.ai.cabinetoffice.gov.uk", *ADDITIONAL_HOSTS])

--- a/django_app/redbox_app/setting_enums.py
+++ b/django_app/redbox_app/setting_enums.py
@@ -2,6 +2,7 @@ import os
 from enum import StrEnum
 
 ADDITIONAL_HOSTS = os.environ.get("ADDITIONAL_HOSTS", "").split(";")
+LOCAL_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
 
 
 class Environment(StrEnum):
@@ -20,8 +21,8 @@ class Environment(StrEnum):
     def uses_minio(self) -> bool:
         return self.is_test
 
-    LOCAL = ("LOCAL", True, ["localhost", "127.0.0.1", "0.0.0.0", *ADDITIONAL_HOSTS])  # noqa: S104 nosec: B104: Not in prod
-    INTEGRATION = ("INTEGRATION", True, ["localhost", "127.0.0.1", "0.0.0.0", *ADDITIONAL_HOSTS])  # noqa: S104 nosec: B104: Not in prod
+    LOCAL = ("LOCAL", True, [*LOCAL_HOSTS, *ADDITIONAL_HOSTS])  # noqa: S104 nosec: B104: Not in prod
+    INTEGRATION = ("INTEGRATION", True, [*LOCAL_HOSTS, *ADDITIONAL_HOSTS])  # noqa: S104 nosec: B104: Not in prod
     DEV = ("DEV", False, ["redbox-dev.ai.cabinetoffice.gov.uk", *ADDITIONAL_HOSTS])
     PREPROD = ("PREPROD", False, ["redbox-preprod.ai.cabinetoffice.gov.uk", *ADDITIONAL_HOSTS])
     PROD = ("PROD", False, ["redbox.ai.cabinetoffice.gov.uk", *ADDITIONAL_HOSTS])

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -13,7 +13,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from storages.backends import s3boto3
 from yarl import URL
 
-from redbox_app.setting_enums import Classification, Environment
+from redbox_app.setting_enums import Classification, Environment, LOCAL_HOSTS
 
 load_dotenv()
 
@@ -196,11 +196,16 @@ CSP_STYLE_SRC = ("'self'",)
 CSP_FRAME_ANCESTORS = ("'none'",)
 CSP_CONNECT_SRC = [
     "'self'",
-    f"wss://{ENVIRONMENT.hosts[0]}/ws/chat/",
+    f"{WEBSOCKET_SCHEME}://{ENVIRONMENT.hosts[0]}/ws/chat/",
     "plausible.io",
     "eu.i.posthog.com",
     "eu-assets.i.posthog.com",
 ]
+
+if ENVIRONMENT.is_test:
+    for host in LOCAL_HOSTS:
+        CSP_CONNECT_SRC.append(f"{WEBSOCKET_SCHEME}://{host}:*/ws/chat/")
+
 
 # https://pypi.org/project/django-permissions-policy/
 PERMISSIONS_POLICY: dict[str, list] = {

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -13,7 +13,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from storages.backends import s3boto3
 from yarl import URL
 
-from redbox_app.setting_enums import Classification, Environment, LOCAL_HOSTS
+from redbox_app.setting_enums import LOCAL_HOSTS, Classification, Environment
 
 load_dotenv()
 


### PR DESCRIPTION
## Context
There was a weird issue locally where users weren't able to access /chat because of how we were generating the chat url. 
<img width="1596" alt="Screenshot 2024-10-11 at 14 22 29" src="https://github.com/user-attachments/assets/28f584f3-5905-4665-95e0-e864d8abbf33">


## Changes proposed in this pull request
Updates the chat url compiler to use the host and port separately to avoid errors.

TODO: fix CSP issues

## Guidance to review
Try this out locally, does it work for you?
I'm going to see if it helps fix the integration tests too.

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
