### PR TITLE
Specify websocket port where required

### DIFF
--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -37,6 +37,7 @@ class ChatsView(View):
         endpoint = URL.build(
             scheme=settings.WEBSOCKET_SCHEME,
             host="localhost" if settings.ENVIRONMENT.is_test else settings.ENVIRONMENT.hosts[0],
+            port=int(request.META["SERVER_PORT"]) if settings.ENVIRONMENT.is_test else None,
             path=r"/ws/chat/",
         )
 


### PR DESCRIPTION
## Context

A fix to ensure the websocket port is specified where required (i.e. locally) but not where not required (i.e. hosted)

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
