### PR TITLE
Alters workflows to use OIDC auth

### DIFF
--- a/.github/workflows/_cicd.yml
+++ b/.github/workflows/_cicd.yml
@@ -26,7 +26,7 @@ jobs:
   release-dev:
     # if: ${{ false }}  # Uncomment this, and comment out the line below, to disable this workflow path
     if: github.event_name == 'workflow_dispatch'
-    uses: i-dot-ai/redbox/.github/workflows/build-and-release.yml@main
+    uses: i-dot-ai/redbox/.github/workflows/build-and-release.yml@danny/oidc-roles
     with:
       environment: dev
       core_infra_repo_reference: ${{ inputs.core_repo_reference }}

--- a/.github/workflows/_cicd.yml
+++ b/.github/workflows/_cicd.yml
@@ -26,7 +26,7 @@ jobs:
   release-dev:
     # if: ${{ false }}  # Uncomment this, and comment out the line below, to disable this workflow path
     if: github.event_name == 'workflow_dispatch'
-    uses: i-dot-ai/redbox/.github/workflows/build-and-release.yml@danny/oidc-roles
+    uses: i-dot-ai/redbox/.github/workflows/build-and-release.yml@main
     with:
       environment: dev
       core_infra_repo_reference: ${{ inputs.core_repo_reference }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -59,7 +59,7 @@ jobs:
     needs:
       - set-vars
       - start-runner
-    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@main
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@danny/oidc-roles
     permissions: write-all
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
@@ -78,7 +78,7 @@ jobs:
       - set-vars
       - start-runner
       - build-image
-    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/apply-terraform.yml@main
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/apply-terraform.yml@danny/oidc-roles
     permissions: write-all
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
@@ -158,7 +158,7 @@ jobs:
     secrets: inherit
 
   stop-runner:
-    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/stop-runner.yml@main
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/stop-runner.yml@danny/oidc-roles
     if: needs.start-runner.outputs.use-persisted == 0 && always()
     permissions: write-all
     needs:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -41,11 +41,13 @@ jobs:
 
   start-runner:
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/start-runner.yml@main
+    permissions: write-all
     needs: set-vars
     with:
       EC2_INSTANCE_TYPE: ${{ needs.set-vars.outputs.ec2-instance-type }}
       RUNNER_SIZE: ${{ needs.set-vars.outputs.runner-size }}
       ENVIRONMENT: ${{ inputs.environment }}
+      USE_OIDC: true
     secrets:
       AWS_GITHUBRUNNER_USER_ACCESS_KEY: ${{ secrets.AWS_GITHUBRUNNER_USER_ACCESS_KEY }}
       AWS_GITHUBRUNNER_USER_SECRET_ID: ${{ secrets.AWS_GITHUBRUNNER_USER_SECRET_ID }}
@@ -58,11 +60,13 @@ jobs:
       - set-vars
       - start-runner
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@main
+    permissions: write-all
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
       INFRASTRUCTURE_FOLDER: "infrastructure/aws"
       COMMIT_HASH: ${{ github.sha }}
+      USE_OIDC: true
     secrets:
       AWS_GITHUBRUNNER_PAT: ${{ secrets.AWS_GITHUBRUNNER_PAT}}
       AWS_GITHUBRUNNER_PAT_USER: ${{ secrets.AWS_GITHUBRUNNER_PAT_USER }}
@@ -75,6 +79,7 @@ jobs:
       - start-runner
       - build-image
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/apply-terraform.yml@main
+    permissions: write-all
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
@@ -85,6 +90,7 @@ jobs:
       CORE_INFRA_REF: ${{ inputs.core_infra_repo_reference }}
       INFRA_CONFIG_REF: ${{ inputs.config_repo_reference }}
       IMAGE_TAG: ${{ github.sha }}
+      USE_OIDC: true
     secrets:
       AWS_GITHUBRUNNER_PAT: ${{ secrets.AWS_GITHUBRUNNER_PAT}}
       AWS_GITHUBRUNNER_PAT_USER: ${{ secrets.AWS_GITHUBRUNNER_PAT_USER }}
@@ -154,6 +160,7 @@ jobs:
   stop-runner:
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/stop-runner.yml@main
     if: needs.start-runner.outputs.use-persisted == 0 && always()
+    permissions: write-all
     needs:
       - set-vars
       - start-runner
@@ -163,6 +170,7 @@ jobs:
     with:
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
       EC2_INSTANCE_ID: ${{ needs.start-runner.outputs.ec2-instance-id }}
+      USE_OIDC: true
     secrets:
       AWS_GITHUBRUNNER_USER_ACCESS_KEY: ${{ secrets.AWS_GITHUBRUNNER_USER_ACCESS_KEY }}
       AWS_GITHUBRUNNER_USER_SECRET_ID: ${{ secrets.AWS_GITHUBRUNNER_USER_SECRET_ID }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -41,7 +41,9 @@ jobs:
 
   start-runner:
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/start-runner.yml@main
-    permissions: write-all
+    permissions:
+      id-token: write
+      contents: read
     needs: set-vars
     with:
       EC2_INSTANCE_TYPE: ${{ needs.set-vars.outputs.ec2-instance-type }}
@@ -60,7 +62,9 @@ jobs:
       - set-vars
       - start-runner
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@main
-    permissions: write-all
+    permissions:
+      id-token: write
+      contents: read
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
@@ -79,7 +83,9 @@ jobs:
       - start-runner
       - build-image
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/apply-terraform.yml@main
-    permissions: write-all
+    permissions:
+      id-token: write
+      contents: read
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
@@ -160,7 +166,9 @@ jobs:
   stop-runner:
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/stop-runner.yml@main
     if: needs.start-runner.outputs.use-persisted == 0 && always()
-    permissions: write-all
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - set-vars
       - start-runner

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -59,7 +59,7 @@ jobs:
     needs:
       - set-vars
       - start-runner
-    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@danny/oidc-roles
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@main
     permissions: write-all
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
@@ -78,7 +78,7 @@ jobs:
       - set-vars
       - start-runner
       - build-image
-    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/apply-terraform.yml@danny/oidc-roles
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/apply-terraform.yml@main
     permissions: write-all
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
@@ -158,7 +158,7 @@ jobs:
     secrets: inherit
 
   stop-runner:
-    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/stop-runner.yml@danny/oidc-roles
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/stop-runner.yml@main
     if: needs.start-runner.outputs.use-persisted == 0 && always()
     permissions: write-all
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,12 @@ jobs:
 
   start-runner:
         uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/start-runner.yml@main
+        permissions: write-all
         needs: set-vars
         with:
             EC2_INSTANCE_TYPE: ${{ needs.set-vars.outputs.ec2-instance-type }}
             RUNNER_SIZE: ${{ needs.set-vars.outputs.runner-size }}
+            USE_OIDC: true
         secrets:
             AWS_GITHUBRUNNER_USER_ACCESS_KEY: ${{ secrets.AWS_GITHUBRUNNER_USER_ACCESS_KEY }}
             AWS_GITHUBRUNNER_USER_SECRET_ID: ${{ secrets.AWS_GITHUBRUNNER_USER_SECRET_ID }}
@@ -44,10 +46,12 @@ jobs:
       - set-vars
       - start-runner
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@main
+    permissions: write-all
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
       INFRASTRUCTURE_FOLDER: "infrastructure/aws"
+      USE_OIDC: true
     secrets:
       AWS_GITHUBRUNNER_PAT: ${{ secrets.AWS_GITHUBRUNNER_PAT}}
       AWS_GITHUBRUNNER_PAT_USER: ${{ secrets.AWS_GITHUBRUNNER_PAT_USER }}
@@ -57,6 +61,7 @@ jobs:
   stop-runner:
         uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/stop-runner.yml@main
         if: needs.start-runner.outputs.use-persisted == 0 && always()
+        permissions: write-all
         needs:
             - set-vars
             - start-runner
@@ -64,6 +69,7 @@ jobs:
         with:
             RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
             EC2_INSTANCE_ID: ${{ needs.start-runner.outputs.ec2-instance-id }}
+            USE_OIDC: true
         secrets:
             AWS_GITHUBRUNNER_USER_ACCESS_KEY: ${{ secrets.AWS_GITHUBRUNNER_USER_ACCESS_KEY }}
             AWS_GITHUBRUNNER_USER_SECRET_ID: ${{ secrets.AWS_GITHUBRUNNER_USER_SECRET_ID }}


### PR DESCRIPTION
## Context

This change removes the need for AWS Access Keys in the workflows and moves us to an OIDC assume role model, meaning temporary access keys are used on each GHA job. We have all of the base configured in our core GHA repo so these downstream changes are minimal.

## Guidance to review

Review that the "AWS Authenication" step within the pipeline works as expected and we don't hit any snags trying to build and or deploy the image.

## Relevant links

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
