### PR TITLE
Stop auto-scrolling when message reaches top of screen

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -106,13 +106,13 @@ class ChatMessage extends HTMLElement {
     chatControllerRef
   ) => {
     // Scroll behaviour - depending on whether user has overridden this or not
-    let userScrollOverride = false;
+    let scrollOverride = false;
     window.addEventListener("scroll", (evt) => {
       if (this.programmaticScroll) {
         this.programmaticScroll = false;
         return;
       }
-      userScrollOverride = true;
+      scrollOverride = true;
     });
 
     let responseContainer = /** @type MarkdownConverter */ (
@@ -224,9 +224,21 @@ class ChatMessage extends HTMLElement {
       }
 
       // ensure new content isn't hidden behind the chat-input
-      if (!userScrollOverride) {
-        this.programmaticScroll = true;
-        this.scrollIntoView({ block: "end" });
+      // but stop scrolling if message is at the top of the screen
+      if (!scrollOverride) {
+        const TOP_POSITION = 88;
+        const boxInfo = this.getBoundingClientRect()
+        const newTopPosition = boxInfo.top - ( boxInfo.height - ( this.previousHeight || boxInfo.height ) );
+        this.previousHeight = boxInfo.height;
+        if (newTopPosition > TOP_POSITION) {
+          this.programmaticScroll = true;
+          this.scrollIntoView({ block: "end" });
+        } else {
+          scrollOverride = true;
+          this.scrollIntoView();
+          window.scrollBy(0, -TOP_POSITION);
+        }
+        
       }
     };
   };

--- a/django_app/frontend/src/js/web-components/chats/chat-title.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-title.js
@@ -69,7 +69,7 @@ export class ChatTitle extends HTMLElement {
         });
 
         if (!this.dataset.sessionId) {
-            document.addEventListener("chat-response-end", this.onFirstResponse);
+            document.addEventListener("chat-response-end", this.#onFirstResponse);
         }
 
         document.addEventListener("chat-title-change", (evt) => {
@@ -96,14 +96,15 @@ export class ChatTitle extends HTMLElement {
         this.editButton?.focus();
     };
 
-    onFirstResponse = (e) => {
+    #onFirstResponse = (e) => {
         this.dataset.title = e.detail.title;
         this.dataset.sessionId = e.detail.session_id;
-        document.removeEventListener("chat-response-end", this.onFirstResponse);
+        document.removeEventListener("chat-response-end", this.#onFirstResponse);
         if (this.input && this.heading) {
             this.input.value = e.detail.title;
             this.heading.textContent = `${e.detail.title}`;
             this.heading.classList.remove("govuk-visually-hidden");
+            window.scrollBy(0, this.heading.getBoundingClientRect().height); // to prevent message jumping when this is made visible
         }
     };
 


### PR DESCRIPTION
## Context

When a new message streams, it streams past the top of the page, meaning users have to scroll up to start reading it.


## Changes proposed in this pull request

Stop scrolling once the message gets to the top of the screen.


## Guidance to review

Ask Redbox to tell you about elephants. It should have enough to say on the matter to check that it stops at the top of the screen.


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
