### PR TITLE
Bugfix/allow no meta data

### DIFF
--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -173,10 +173,12 @@ class MetadataLoader:
         except ConnectionError as e:
             logger.warning(f"Retrying due to HTTPError {e}")
         except json.JSONDecodeError:
+            logger.error("failed to encode metadata into json")
             # replace with fail safe metadata
-            return None
+            return {}
         except Exception as e:
-            raise Exception(f"Some error happened in metadata extraction. {e}")
+            logger.error(f"Unhandled error happened in metadata extraction. {e}")
+            return {}
 
 
 def coerce_to_string_list(input_data: str | list[Any]) -> list[str]:

--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -175,10 +175,10 @@ class MetadataLoader:
         except json.JSONDecodeError:
             logger.error("failed to encode metadata into json")
             # replace with fail safe metadata
-            return {}
+            return metadata
         except Exception as e:
             logger.error(f"Unhandled error happened in metadata extraction. {e}")
-            return {}
+            return metadata
 
 
 def coerce_to_string_list(input_data: str | list[Any]) -> list[str]:


### PR DESCRIPTION
## Context

As a user I do not want the file ingest to fail just because RB failed to enhance the metadata

The actual error is this:

``` 2024-10-18 11:20:35,514 ERROR monitor: Failed 'redbox_app.worker.ingest' (Bookings_v4KpDVw.xlsx) - Some error happened in metadata extraction. Error code: 400 - {'error': {'message': "Invalid 'messages[1].content': string too long. Expected a string with maximum length 1048576, but got a string with length 1239399 instead.", 'type': 'invalid_request_error', 'param': 'messages[1].content', 'code': 'string_above_max_length'}} : Traceback (most recent call last):```

So although the proposed fix doesnt address the underlying issue it will at least allow users to use their data until we find a proper solution

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
