### PR TITLE
Reset message-input height after sending message

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-controller.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-controller.js
@@ -12,11 +12,11 @@ class ChatController extends HTMLElement {
 
     messageForm?.addEventListener("submit", (evt) => {
       evt.preventDefault();
-      const textArea = /** @type {HTMLInputElement | null} */ (
-        document.querySelector(".js-user-text")
+      const messageInput = /** @type {MessageInput | null} */ (
+        document.querySelector("message-input")
       );
-      const userText = textArea?.value.trim();
-      if (!textArea || !userText) {
+      const userText = messageInput?.getValue();
+      if (!messageInput || !userText) {
         return;
       }
 
@@ -25,7 +25,7 @@ class ChatController extends HTMLElement {
       userMessage.setAttribute("data-role", "user");
       messageContainer?.insertBefore(userMessage, insertPosition);
 
-      let aiMessage = /** @type {ChatMessage} */ (
+      let aiMessage = /** @type {import("./chat-message").ChatMessage} */ (
         document.createElement("chat-message")
       );
       aiMessage.setAttribute("data-role", "ai");
@@ -33,7 +33,7 @@ class ChatController extends HTMLElement {
 
       const llm = /** @type {HTMLInputElement | null}*/ (
         document.querySelector("#llm-selector")
-      )?.value;
+      )?.value || "";
 
       aiMessage.stream(
         userText,
@@ -51,7 +51,7 @@ class ChatController extends HTMLElement {
       if (feedbackButtons) {
         feedbackButtons.dataset.status = "";
       }
-      textArea.value = "";
+      messageInput.reset();
 
       // if a route has been intentionally specified by a user, send an event to Plausible
       (() => {

--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -27,7 +27,8 @@ const sendTooltipViewEvent = (evt) => {
   });
 })();
 
-class ChatMessage extends HTMLElement {
+
+export class ChatMessage extends HTMLElement {
   constructor() {
     super();
     this.programmaticScroll = false;
@@ -115,12 +116,13 @@ class ChatMessage extends HTMLElement {
       scrollOverride = true;
     });
 
-    let responseContainer = /** @type MarkdownConverter */ (
+    let responseContainer = /** @type {import("../markdown-converter").MarkdownConverter} */ (
       this.querySelector("markdown-converter")
     );
     let sourcesContainer = /** @type SourcesList */ (
       this.querySelector("sources-list")
     );
+    /** @type {FeedbackButtons | null} */
     let feedbackContainer = this.querySelector("feedback-buttons");
     let responseLoading = /** @type HTMLElement */ (
       this.querySelector(".rb-loading-ellipsis")
@@ -207,7 +209,7 @@ class ChatMessage extends HTMLElement {
         }
       } else if (response.type === "end") {
         sourcesContainer.showCitations(response.data.message_id);
-        feedbackContainer.showFeedback(response.data.message_id);
+        feedbackContainer?.showFeedback(response.data.message_id);
         const chatResponseEndEvent = new CustomEvent("chat-response-end", {
           detail: {
             title: response.data.title,
@@ -219,8 +221,10 @@ class ChatMessage extends HTMLElement {
         this.querySelector(".govuk-notification-banner")?.removeAttribute(
           "hidden"
         );
-        this.querySelector(".govuk-notification-banner__heading").innerHTML =
-          response.data;
+        let errorContentContainer = this.querySelector(".govuk-notification-banner__heading");
+        if (errorContentContainer) {
+          errorContentContainer.innerHTML = response.data;
+        }
       }
 
       // ensure new content isn't hidden behind the chat-input

--- a/django_app/frontend/src/js/web-components/chats/message-input.js
+++ b/django_app/frontend/src/js/web-components/chats/message-input.js
@@ -2,29 +2,59 @@
 
 class MessageInput extends HTMLElement {
 
+    constructor() {
+        super();
+        this.textarea = this.querySelector("textarea");
+    }
+
     connectedCallback() {
 
-        const textarea = this.querySelector('textarea');
-        if (!textarea) {
+        if (!this.textarea) {
             return;
         }
 
         // Submit form on enter-key press (providing shift isn't being pressed)
-        textarea.addEventListener('keypress', (evt) => {
-            if (evt.key === 'Enter' && !evt.shiftKey) {
+        this.textarea.addEventListener('keypress', (evt) => {
+            if (evt.key === 'Enter' && !evt.shiftKey && this.textarea) {
                 evt.preventDefault();
-                if (textarea.value.trim()) {
+                if (this.textarea.value.trim()) {
                     this.closest('form')?.requestSubmit();
                 }
             }
         });
 
         // expand textarea as user adds lines
-        textarea.addEventListener('input', () => {
-            textarea.style.height = 'auto';
-            textarea.style.height = `${textarea.scrollHeight}px`;
+        this.textarea.addEventListener('input', () => {
+            this.#adjustHeight();
         });
 
+    }
+
+    #adjustHeight = () => {
+        if (!this.textarea) {
+            return;
+        }
+        this.textarea.style.height = 'auto';
+        this.textarea.style.height = `${this.textarea.scrollHeight}px`;
+    };
+
+    /**
+     * Returns the current message
+     * @returns string
+     */
+    getValue = () => {
+        return this.querySelector("textarea")?.value.trim() || "";
+    }
+
+    /**
+     * Clears the message and resets to starting height
+     */
+    reset = () => {
+        if (!this.textarea) {
+            return;
+        }
+        this.textarea.value = "";
+        this.#adjustHeight();
     }
   
 }

--- a/django_app/frontend/src/js/web-components/markdown-converter.js
+++ b/django_app/frontend/src/js/web-components/markdown-converter.js
@@ -3,7 +3,7 @@
 /** @type {import ('showdown')} */
 let showdown = window["showdown"];
 
-class MarkdownConverter extends HTMLElement {
+export class MarkdownConverter extends HTMLElement {
   /**
    * Takes markdown and inserts as HTML
    * @param {string} markdown


### PR DESCRIPTION
## Context

The message input box can expand to fit content. But the height doesn't reset again until you type a new message into it.


## Changes proposed in this pull request

* Reset the message input height immediately after sending the message
* Fix a few type import errors


## Guidance to review

Send a multi-line message, watch it reset to original size.


## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
