### PR TITLE
fix ingest error due to metadata size exceed max size

### DIFF
--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -67,7 +67,7 @@ class MetadataLoader:
 
     @staticmethod
     def merge_unstructured_metadata(
-        x: dict, y: dict, ignore: set[str] = None, max_size: int = None
+        x: dict, y: dict, ignore: set[str] | None = None, max_size: int | None = None
     ) -> dict:
         """
         Combine 2 dicts without deleting any elements. If the key is present in both,

--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -27,7 +27,9 @@ else:
 
 
 class MetadataLoader:
-    def __init__(self, env: Settings, s3_client: S3Client, file_name: str, metadata: dict = None):
+    def __init__(
+        self, env: Settings, s3_client: S3Client, file_name: str, metadata: dict = None
+    ):
         self.env = env
         self.s3_client = s3_client
         self.llm = get_chat_llm(env.metadata_extraction_llm)
@@ -47,7 +49,9 @@ class MetadataLoader:
             tokens += chunk["text"]
         return tokens
 
-    def get_doc_metadata(self, chunks: list[dict], n: int, ignore: list[str] = None) -> dict[str, Any]:
+    def get_doc_metadata(
+        self, chunks: list[dict], n: int, ignore: list[str] = None, max_size: int = None
+    ) -> dict[str, Any]:
         """
         Use the first n chunks to get metadata using unstructured.
         Metadata keys in the ignore list will be excluded from the result.
@@ -56,45 +60,72 @@ class MetadataLoader:
         for i, chunk in enumerate(chunks):
             if i > n:
                 return metadata
-            metadata = self.merge_unstructured_metadata(metadata, chunk["metadata"], ignore)
+            metadata = self.merge_unstructured_metadata(
+                metadata, chunk["metadata"], ignore, max_size
+            )
         return metadata
 
     @staticmethod
-    def merge_unstructured_metadata(x: dict, y: dict, ignore: set[str] = None) -> dict:
+    def merge_unstructured_metadata(
+        x: dict, y: dict, ignore: set[str] = None, max_size: int = None
+    ) -> dict:
         """
         Combine 2 dicts without deleting any elements. If the key is present in both,
         combine values into a list. If value is in a list, extend with unique values.
-        Keys in the ignore list will be excluded from the result.
+        Keys in the ignore list will be excluded from the result. Stop combining if
+        the total size of metadata exceeds a given threshold.
+
+        :param x: First metadata dictionary
+        :param y: Second metadata dictionary
+        :param ignore: Set of keys to ignore while merging
+        :param max_size: Maximum allowed size for combined metadata (sum of lengths of values' string representation)
+        :return: Merged metadata dictionary
         """
         if ignore is None:
-            ignore = []
+            ignore = set()
 
         combined = {}
+        total_size = 0  # Track the total size of combined values
 
         for key in set(x) | set(y):
             if key in ignore:
                 continue
 
+            # Determine the value to combine
             if key in x and key in y:
                 if isinstance(x[key], list) or isinstance(y[key], list):
-                    combined[key] = list(set(x[key] + (y[key] if isinstance(y[key], list) else [y[key]])))
+                    combined_value = list(
+                        set(x[key] + (y[key] if isinstance(y[key], list) else [y[key]]))
+                    )
                 else:
-                    combined[key] = [x[key], y[key]]
+                    combined_value = [x[key], y[key]]
             elif key in x:
-                combined[key] = x[key]
+                combined_value = x[key]
             else:
-                combined[key] = y[key]
+                combined_value = y[key]
+
+            # Calculate the size of the new value and check if it exceeds the threshold
+            combined_value_size = len(str(combined_value))
+            if max_size is not None and total_size + combined_value_size > max_size:
+                break
+
+            combined[key] = combined_value
+            total_size += combined_value_size  # Update the total size with the size of the new value
 
         return combined
 
     def _get_file_bytes(self, s3_client: S3Client, file_name: str) -> BytesIO:
-        return s3_client.get_object(Bucket=self.env.bucket_name, Key=file_name)["Body"].read()
+        return s3_client.get_object(Bucket=self.env.bucket_name, Key=file_name)[
+            "Body"
+        ].read()
 
     def _chunking(self) -> Any:
         """
         Chunking data using local unstructured
         """
-        file_bytes = self._get_file_bytes(s3_client=self.s3_client, file_name=self.file_name)
+        file_bytes = self._get_file_bytes(
+            s3_client=self.s3_client, file_name=self.file_name
+        )
         url = f"http://{self.env.unstructured_host}:8000/general/v0/general"
         files = {
             "files": (self.file_name, file_bytes),
@@ -131,7 +162,9 @@ class MetadataLoader:
             first_n = self.get_first_n_tokens(elements, 1_000)
 
             # Get whatever metadata we can from processed document
-            doc_metadata = self.get_doc_metadata(chunks=elements, n=3, ignore=None)
+            doc_metadata = self.get_doc_metadata(
+                chunks=elements, n=3, ignore=None, max_size=1048576 - len(first_n)
+            )
 
             # Generate new metadata
             res = self.create_file_metadata(first_n, doc_metadata)
@@ -145,7 +178,17 @@ class MetadataLoader:
                     # missing keys
                     self.metadata = self.default_metadata
 
-    def create_file_metadata(self, page_content: str, metadata: dict[str, Any]) -> dict[str, Any]:
+    def reduce_metadata(page_content: str, metadata: dict[str, Any]):
+        """
+        Reduce the page + metadata length so it doesn't exceed maximum length 1048576.
+        """
+        total_length = 0
+        for m in metadata:
+            total_length += len(m)
+
+    def create_file_metadata(
+        self, page_content: str, metadata: dict[str, Any]
+    ) -> dict[str, Any]:
         """Uses a sample of the document and any extracted metadata to generate further metadata."""
         metadata_chain = (
             ChatPromptTemplate.from_messages(
@@ -169,7 +212,9 @@ class MetadataLoader:
         )
 
         try:
-            return metadata_chain.invoke({"page_content": page_content, "metadata": metadata})
+            return metadata_chain.invoke(
+                {"page_content": page_content, "metadata": metadata}
+            )
         except ConnectionError as e:
             logger.warning(f"Retrying due to HTTPError {e}")
         except json.JSONDecodeError:

--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -160,7 +160,7 @@ class MetadataLoader:
 
             # Get whatever metadata we can from processed document
             doc_metadata = self.get_doc_metadata(
-                chunks=elements, n=3, ignore=None, max_size=1048576 - len(first_n)
+                chunks=elements, n=3, ignore=None, max_size=524288 - len(first_n)
             )
 
             # Generate new metadata
@@ -174,12 +174,6 @@ class MetadataLoader:
                 else:
                     # missing keys
                     self.metadata = self.default_metadata
-
-    def reduce_metadata(page_content: str, metadata: dict[str, Any]):
-        """
-        Reduce the page + metadata length so it doesn't exceed maximum length 1048576.
-        """
-        total_length = sum(map(len, metadata))
 
     def create_file_metadata(
         self, page_content: str, metadata: dict[str, Any]

--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -81,28 +81,25 @@ class MetadataLoader:
         :param max_size: Maximum allowed size for combined metadata (sum of lengths of values' string representation)
         :return: Merged metadata dictionary
         """
+
+        def to_list(obj):
+            if obj is None:
+                return []
+            if not isinstance(obj, list):
+                return [obj]
+            return obj
+
         if ignore is None:
             ignore = set()
 
         combined = {}
-        total_size = 0  # Track the total size of combined values
+        total_size = 0
 
+        combined_value = {}
         for key in set(x) | set(y):
-            if key in ignore:
-                continue
-
-            # Determine the value to combine
-            if key in x and key in y:
-                if isinstance(x[key], list) or isinstance(y[key], list):
-                    combined_value = list(
-                        set(x[key] + (y[key] if isinstance(y[key], list) else [y[key]]))
-                    )
-                else:
-                    combined_value = [x[key], y[key]]
-            elif key in x:
-                combined_value = x[key]
-            else:
-                combined_value = y[key]
+            x_value = to_list(x.get(key, []))
+            y_value = to_list(y.get(key, []))
+            combined_value = x_value + y_value
 
             # Calculate the size of the new value and check if it exceeds the threshold
             combined_value_size = len(str(combined_value))
@@ -110,7 +107,7 @@ class MetadataLoader:
                 break
 
             combined[key] = combined_value
-            total_size += combined_value_size  # Update the total size with the size of the new value
+            total_size += combined_value_size
 
         return combined
 
@@ -183,8 +180,6 @@ class MetadataLoader:
         Reduce the page + metadata length so it doesn't exceed maximum length 1048576.
         """
         total_length = sum(map(len, metadata))
-        for m in metadata:
-            total_length += len(m)
 
     def create_file_metadata(
         self, page_content: str, metadata: dict[str, Any]

--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -182,7 +182,7 @@ class MetadataLoader:
         """
         Reduce the page + metadata length so it doesn't exceed maximum length 1048576.
         """
-        total_length = 0
+        total_length = sum(map(len, metadata))
         for m in metadata:
             total_length += len(m)
 


### PR DESCRIPTION
## Context

Ingestion error due to metadata exceeding maximum length

Example error message:

"Invalid 'messages[1].content': string too long. Expected a string with maximum length 1048576, but got a string with length 7485384 instead."

## Changes proposed in this pull request

Update the `merge_unstructured_metadata` function to not adding more metadata if it reach max length

## Guidance to review

At the moment I'm passing hard coded max length in: 

```
doc_metadata = self.get_doc_metadata(
                chunks=elements, n=3, ignore=None, max_size=1048576 - len(first_n)
            )
```

but maybe we can get this from somewhere else?
## Relevant links


## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests(https://github.com/i-dot-ai/redbox/actions/runs/11501086443)
