### PR TITLE
Feature/streaming with citations

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -289,12 +289,13 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 payload = {"url": ref, "original_file_name": None}
                 response_sources = [
                     Source(
-                        source=ref.metadata["uri"],
-                        source_type=ref.metadata["creator_type"],
-                        document_name=ref.metadata["uri"].split("/")[-1],
-                        highlighted_text_in_source=ref.page_content,
-                        page_numbers=parse_page_number(ref.metadata.get("page_number")),
+                        source=cited_chunk.metadata["uri"],
+                        source_type=cited_chunk.metadata["creator_type"],
+                        document_name=cited_chunk.metadata["uri"].split("/")[-1],
+                        highlighted_text_in_source=cited_chunk.page_content,
+                        page_numbers=parse_page_number(cited_chunk.metadata.get("page_number")),
                     )
+                    for cited_chunk in sources
                 ]
 
             await self.send_to_client("source", payload)

--- a/redbox-core/redbox/chains/components.py
+++ b/redbox-core/redbox/chains/components.py
@@ -3,20 +3,25 @@ import logging
 import os
 from functools import cache
 
+import pydantic
 import tiktoken
 
 from dotenv import load_dotenv
 from langchain_core.embeddings import Embeddings, FakeEmbeddings
 from langchain_core.tools import StructuredTool
+from langchain_core.runnables import Runnable
 from langchain_core.utils import convert_to_secret_str
 from langchain_elasticsearch import ElasticsearchRetriever
 from langchain_openai.embeddings import AzureOpenAIEmbeddings, OpenAIEmbeddings
+from langchain_core.output_parsers import PydanticOutputParser
 
+
+from redbox.chains.parser import StreamingJsonOutputParser
 from redbox.models.settings import Settings
 from redbox.retriever import AllElasticsearchRetriever, ParameterisedElasticsearchRetriever, MetadataRetriever
 from langchain_community.embeddings import BedrockEmbeddings
 from langchain.chat_models import init_chat_model
-from redbox.models.chain import ChatLLMBackend
+from redbox.models.chain import ChatLLMBackend, StructuredResponseWithCitations
 
 
 logger = logging.getLogger(__name__)
@@ -106,3 +111,17 @@ def get_metadata_retriever(env: Settings):
         es_client=env.elasticsearch_client(),
         index_name=env.elastic_chunk_alias,
     )
+
+
+def get_structured_response_with_citations_parser() -> tuple[Runnable, str]:
+    """
+    Returns the output parser (as a runnable) for creating the StructuredResponseWithCitations object
+    while streaming the answer tokens
+    Also returns the format instructions for this structure for use in the prompt
+    """
+    #pydantic_parser = PydanticOutputParser(pydantic_object=StructuredResponseWithCitations)
+    parser = StreamingJsonOutputParser(
+        name_of_streamed_field="answer",
+        pydantic_schema_object=StructuredResponseWithCitations
+    )
+    return (parser, parser.get_format_instructions())

--- a/redbox-core/redbox/chains/components.py
+++ b/redbox-core/redbox/chains/components.py
@@ -3,7 +3,6 @@ import logging
 import os
 from functools import cache
 
-import pydantic
 import tiktoken
 
 from dotenv import load_dotenv
@@ -13,7 +12,6 @@ from langchain_core.runnables import Runnable
 from langchain_core.utils import convert_to_secret_str
 from langchain_elasticsearch import ElasticsearchRetriever
 from langchain_openai.embeddings import AzureOpenAIEmbeddings, OpenAIEmbeddings
-from langchain_core.output_parsers import PydanticOutputParser
 
 
 from redbox.chains.parser import StreamingJsonOutputParser
@@ -119,9 +117,8 @@ def get_structured_response_with_citations_parser() -> tuple[Runnable, str]:
     while streaming the answer tokens
     Also returns the format instructions for this structure for use in the prompt
     """
-    #pydantic_parser = PydanticOutputParser(pydantic_object=StructuredResponseWithCitations)
+    # pydantic_parser = PydanticOutputParser(pydantic_object=StructuredResponseWithCitations)
     parser = StreamingJsonOutputParser(
-        name_of_streamed_field="answer",
-        pydantic_schema_object=StructuredResponseWithCitations
+        name_of_streamed_field="answer", pydantic_schema_object=StructuredResponseWithCitations
     )
     return (parser, parser.get_format_instructions())

--- a/redbox-core/redbox/chains/parser.py
+++ b/redbox-core/redbox/chains/parser.py
@@ -1,0 +1,99 @@
+
+from collections.abc import AsyncIterator
+from typing import Any, Iterator, Union, override
+import json
+
+from langchain_core.output_parsers import JsonOutputParser, BaseCumulativeTransformOutputParser
+from langchain_core.output_parsers.format_instructions import JSON_FORMAT_INSTRUCTIONS
+from langchain_core.outputs import Generation
+from langchain_core.messages import BaseMessage, AIMessage, BaseMessageChunk
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, GenerationChunk
+from langchain_core.callbacks.manager import dispatch_custom_event
+from langchain_core.utils.json import parse_json_markdown
+from pydantic import BaseModel
+
+
+from redbox.models.graph import RedboxEventType
+    
+
+class StreamingJsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
+
+    diff: bool = False #Ignored
+    name_of_streamed_field: str = "answer"
+    pydantic_schema_object: type[BaseModel]
+
+    def parse_partial_json(self, text: str):
+        try:
+            return parse_json_markdown(text)
+        except json.JSONDecodeError:
+            return None
+    
+    def _to_generation_chunk(self, chunk: Union[str, BaseMessage]):
+        chunk_gen: Union[GenerationChunk, ChatGenerationChunk]
+        if isinstance(chunk, BaseMessageChunk):
+            chunk_gen = ChatGenerationChunk(message=chunk)
+        elif isinstance(chunk, BaseMessage):
+            chunk_gen = ChatGenerationChunk(
+                message=BaseMessageChunk(**chunk.model_dump())
+            )
+        else:
+            chunk_gen = GenerationChunk(text=chunk)
+        return chunk_gen
+
+    def _transform(self, input: Iterator[Union[str, BaseMessage]]) -> Iterator[Any]:
+        acc_gen: Union[GenerationChunk, ChatGenerationChunk, None] = None
+        field_length_at_last_run: int = 0
+        for chunk in input:
+            chunk_gen = self._to_generation_chunk(chunk)
+            acc_gen = chunk_gen if acc_gen is None else acc_gen + chunk_gen  # type: ignore[operator]
+            
+            if parsed := self.parse_partial_json(acc_gen.text):
+                if (field_content := parsed.get(self.name_of_streamed_field)):
+                    if (new_tokens := field_content[field_length_at_last_run:]):
+                        dispatch_custom_event(RedboxEventType.response_tokens, data=new_tokens)
+                        field_length_at_last_run = len(field_content)
+                        yield self.pydantic_schema_object.model_validate(parsed)
+
+    async def _atransform(
+        self, input: AsyncIterator[Union[str, BaseMessage]]
+    ) -> AsyncIterator[Any]:
+        acc_gen: Union[GenerationChunk, ChatGenerationChunk, None] = None
+        async for chunk in input:
+            chunk_gen = self._to_generation_chunk(chunk)
+            acc_gen = chunk_gen if acc_gen is None else acc_gen + chunk_gen  # type: ignore[operator]
+            
+            if parsed := self.parse_partial_json(acc_gen.text):
+                if (field_content := parsed.get(self.name_of_streamed_field)):
+                    if (new_tokens := field_content[field_length_at_last_run:]):
+                        dispatch_custom_event(RedboxEventType.response_tokens, data=new_tokens)
+                        field_length_at_last_run = len(field_content)
+                        yield self.pydantic_schema_object.model_validate(parsed)
+
+    @property
+    def _type(self) -> str:
+        return "streaming_json_output_parser"
+    
+    def get_format_instructions(self) -> str:
+        """Return the format instructions for the JSON output.
+
+        Returns:
+            The format instructions for the JSON output.
+        """
+        if self.pydantic_schema_object is None:
+            return "Return a JSON object."
+        else:
+            # Copy schema to avoid altering original Pydantic schema.
+            schema = dict(self.pydantic_schema_object.model_json_schema().items())
+
+            # Remove extraneous fields.
+            reduced_schema = schema
+            if "title" in reduced_schema:
+                del reduced_schema["title"]
+            if "type" in reduced_schema:
+                del reduced_schema["type"]
+            # Ensure json in context is well-formed with double quotes.
+            schema_str = json.dumps(reduced_schema)
+            return JSON_FORMAT_INSTRUCTIONS.format(schema=schema_str)
+
+    def parse(self, text: str) -> Any:
+        return super().parse(text)

--- a/redbox-core/redbox/chains/parser.py
+++ b/redbox-core/redbox/chains/parser.py
@@ -1,24 +1,31 @@
-
 from collections.abc import AsyncIterator
-from typing import Any, Iterator, Union, override
+from typing import Any, Iterator, Union
 import json
 
-from langchain_core.output_parsers import JsonOutputParser, BaseCumulativeTransformOutputParser
+from langchain_core.output_parsers import BaseCumulativeTransformOutputParser
 from langchain_core.output_parsers.format_instructions import JSON_FORMAT_INSTRUCTIONS
-from langchain_core.outputs import Generation
-from langchain_core.messages import BaseMessage, AIMessage, BaseMessageChunk
-from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, GenerationChunk
+from langchain_core.messages import BaseMessage, BaseMessageChunk
+from langchain_core.outputs import ChatGenerationChunk, GenerationChunk
 from langchain_core.callbacks.manager import dispatch_custom_event
 from langchain_core.utils.json import parse_json_markdown
 from pydantic import BaseModel
 
 
 from redbox.models.graph import RedboxEventType
-    
+
 
 class StreamingJsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
+    """
+    A Pydantic output parser which emits token events for a given field from the JSON intermediate stage.
+    This allows streaming a field (answer) while maintaining the Pydantic object through the pipeline for tracking
+    citations.
 
-    diff: bool = False #Ignored
+    This class is mostly based on existing implementations in BaseCumulativeTransformOutputParser and JsonOutputParser.
+    This custom parser is here to allow emitting custom events and maintaining state for each parse, every invocation of the
+    parser tracks the current length of the answer field to allow emitting delta token events.
+    """
+
+    diff: bool = False  # Ignored
     name_of_streamed_field: str = "answer"
     pydantic_schema_object: type[BaseModel]
 
@@ -27,15 +34,13 @@ class StreamingJsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
             return parse_json_markdown(text)
         except json.JSONDecodeError:
             return None
-    
+
     def _to_generation_chunk(self, chunk: Union[str, BaseMessage]):
         chunk_gen: Union[GenerationChunk, ChatGenerationChunk]
         if isinstance(chunk, BaseMessageChunk):
             chunk_gen = ChatGenerationChunk(message=chunk)
         elif isinstance(chunk, BaseMessage):
-            chunk_gen = ChatGenerationChunk(
-                message=BaseMessageChunk(**chunk.model_dump())
-            )
+            chunk_gen = ChatGenerationChunk(message=BaseMessageChunk(**chunk.model_dump()))
         else:
             chunk_gen = GenerationChunk(text=chunk)
         return chunk_gen
@@ -46,25 +51,24 @@ class StreamingJsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
         for chunk in input:
             chunk_gen = self._to_generation_chunk(chunk)
             acc_gen = chunk_gen if acc_gen is None else acc_gen + chunk_gen  # type: ignore[operator]
-            
+
             if parsed := self.parse_partial_json(acc_gen.text):
-                if (field_content := parsed.get(self.name_of_streamed_field)):
-                    if (new_tokens := field_content[field_length_at_last_run:]):
+                if field_content := parsed.get(self.name_of_streamed_field):
+                    if new_tokens := field_content[field_length_at_last_run:]:
                         dispatch_custom_event(RedboxEventType.response_tokens, data=new_tokens)
                         field_length_at_last_run = len(field_content)
                         yield self.pydantic_schema_object.model_validate(parsed)
 
-    async def _atransform(
-        self, input: AsyncIterator[Union[str, BaseMessage]]
-    ) -> AsyncIterator[Any]:
+    async def _atransform(self, input: AsyncIterator[Union[str, BaseMessage]]) -> AsyncIterator[Any]:
         acc_gen: Union[GenerationChunk, ChatGenerationChunk, None] = None
+        field_length_at_last_run: int = 0
         async for chunk in input:
             chunk_gen = self._to_generation_chunk(chunk)
             acc_gen = chunk_gen if acc_gen is None else acc_gen + chunk_gen  # type: ignore[operator]
-            
+
             if parsed := self.parse_partial_json(acc_gen.text):
-                if (field_content := parsed.get(self.name_of_streamed_field)):
-                    if (new_tokens := field_content[field_length_at_last_run:]):
+                if field_content := parsed.get(self.name_of_streamed_field):
+                    if new_tokens := field_content[field_length_at_last_run:]:
                         dispatch_custom_event(RedboxEventType.response_tokens, data=new_tokens)
                         field_length_at_last_run = len(field_content)
                         yield self.pydantic_schema_object.model_validate(parsed)
@@ -72,7 +76,7 @@ class StreamingJsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
     @property
     def _type(self) -> str:
         return "streaming_json_output_parser"
-    
+
     def get_format_instructions(self) -> str:
         """Return the format instructions for the JSON output.
 

--- a/redbox-core/redbox/graph/nodes/processes.py
+++ b/redbox-core/redbox/graph/nodes/processes.py
@@ -303,7 +303,6 @@ def build_tool_pattern(
                     tool_called_state_update = {"tool_calls": {tool_id: {"called": True, "tool": tool_call}}}
                     state_updates.append(result_state_update | tool_called_state_update)
                 except Exception as e:
-                    raise e
                     state_updates.append({"tool_calls": {tool_id: {"called": True, "tool": tool_call}}})
                     log.warning(f"Error invoking tool {tool_call['name']}: {e} \n")
                     return {}

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -1,4 +1,3 @@
-from langchain.output_parsers import PydanticOutputParser
 from langchain_core.tools import StructuredTool
 from langchain_core.vectorstores import VectorStoreRetriever
 from langgraph.graph import END, START, StateGraph
@@ -38,7 +37,7 @@ from redbox.graph.nodes.sends import (
     build_document_group_send,
     build_tool_send,
 )
-from redbox.models.chain import StructuredResponseWithCitations, RedboxState
+from redbox.models.chain import RedboxState
 from redbox.models.chat import ChatRoute, ErrorRoute
 from redbox.models.graph import ROUTABLE_KEYWORDS, RedboxActivityEvent
 from redbox.transform import (
@@ -185,7 +184,7 @@ def get_agentic_search_graph(tools: dict[str, StructuredTool], debug: bool = Fal
         "p_stuff_docs_agent",
         build_stuff_pattern(
             prompt_set=PromptSet.Search,
-            final_response_chain=False, #Output Parser handles token streaming
+            final_response_chain=False,  # Output Parser handles token streaming
             output_parser=citations_output_parser,
             format_instructions=format_instructions,
         ),

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -5,6 +5,7 @@ from langgraph.graph import END, START, StateGraph
 from langgraph.graph.graph import CompiledGraph
 
 
+from redbox.chains.components import get_structured_response_with_citations_parser
 from redbox.chains.runnables import build_self_route_output_parser
 from redbox.graph.edges import (
     build_documents_bigger_than_context_conditional,
@@ -164,7 +165,7 @@ def get_search_graph(
 def get_agentic_search_graph(tools: dict[str, StructuredTool], debug: bool = False) -> CompiledGraph:
     """Creates a subgraph for agentic RAG."""
 
-    citations_output_parser = PydanticOutputParser(pydantic_object=StructuredResponseWithCitations)
+    citations_output_parser, format_instructions = get_structured_response_with_citations_parser()
     builder = StateGraph(RedboxState)
     # Tools
     agent_tool_names = ["_search_documents", "_search_wikipedia"]
@@ -184,9 +185,9 @@ def get_agentic_search_graph(tools: dict[str, StructuredTool], debug: bool = Fal
         "p_stuff_docs_agent",
         build_stuff_pattern(
             prompt_set=PromptSet.Search,
-            final_response_chain=True,
+            final_response_chain=False, #Output Parser handles token streaming
             output_parser=citations_output_parser,
-            format_instructions=citations_output_parser.get_format_instructions(),
+            format_instructions=format_instructions,
         ),
     )
     builder.add_node(

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -84,21 +84,21 @@ class AISettings(BaseModel):
 
 
 class Source(BaseModel):
-    source: str = Field(description="URL or reference to the source")
+    source: str = Field(description="URL or reference to the source", default="")
     source_type: str = Field(description="CreatorType of tool", default="Unknown")
     document_name: str = ""
     highlighted_text_in_source: str = ""
-    page_numbers: list[int] = Field(description="Page Number in document the highlighted text is on", default=1)
+    page_numbers: list[int] = Field(description="Page Number in document the highlighted text is on", default=[1])
 
 
 class Citation(BaseModel):
-    text_in_answer: str
-    sources: list[Source]
+    text_in_answer: str = ""
+    sources: list[Source] = Field(default_factory=list)
 
 
 class StructuredResponseWithCitations(BaseModel):
-    answer: str = Field(description="Markdown structured answer to the query")
-    citations: list[Citation]
+    answer: str = Field(description="Markdown structured answer to the query", default="")
+    citations: list[Citation] = Field(default_factory=list)
 
 
 class DocumentState(TypedDict):

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -214,7 +214,7 @@ def metadata_reducer(
         return current
 
     return RequestMetadata(
-        llm_calls=sorted(list(set(current.llm_calls) | set(update.llm_calls)), key=lambda c: c.timestamp),
+        llm_calls=sorted(set(current.llm_calls) | set(update.llm_calls), key=lambda c: c.timestamp),
         selected_files_total_tokens=update.selected_files_total_tokens or current.selected_files_total_tokens,
         number_of_selected_files=update.number_of_selected_files or current.number_of_selected_files,
     )

--- a/redbox-core/redbox/models/file.py
+++ b/redbox-core/redbox/models/file.py
@@ -40,4 +40,4 @@ class UploadedFileMetadata(ChunkMetadata):
     name: str
     description: str
     keywords: list[str]
-    creator_type: Literal["Wikipedia", "UserUploadedDocument"] = "UserUploadedDocument"
+    creator_type: Literal["UserUploadedDocument"] = "UserUploadedDocument"

--- a/redbox-core/tests/graph/test_app.py
+++ b/redbox-core/tests/graph/test_app.py
@@ -2,7 +2,6 @@ import copy
 from typing import Any
 from uuid import uuid4
 
-from cv2 import exp
 import pytest
 from langchain_core.documents import Document
 from langchain_core.messages import AIMessage
@@ -357,7 +356,7 @@ TEST_CASES = [
                                             source="SomeAIGuy",
                                             document_name="http://localhost/someaiguy.html",
                                             highlighted_text_in_source="I lied about AI",
-                                            page_numbers=[1]
+                                            page_numbers=[1],
                                         )
                                     ],
                                 )
@@ -536,7 +535,9 @@ async def test_streaming(test: RedboxChatTestCase, env: Settings, mocker: Mocker
 
     # Bit of a bodge to retain the ability to check that the LLM streaming is working in most cases
     if not route_name.startswith("error"):
-        assert len(token_events) > 1, f"Expected tokens as a stream. Received: {token_events}" #Temporarily turning off streaming check
+        assert (
+            len(token_events) > 1
+        ), f"Expected tokens as a stream. Received: {token_events}"  # Temporarily turning off streaming check
         assert len(metadata_events) == len(
             test_case.test_data.llm_responses
         ), f"Expected {len(test_case.test_data.llm_responses)} metadata events. Received {len(metadata_events)}"
@@ -557,7 +558,9 @@ async def test_streaming(test: RedboxChatTestCase, env: Settings, mocker: Mocker
         metadata_events,
     )
 
-    expected_text = test.test_data.expected_text if test.test_data.expected_text is not None else test.test_data.llm_responses[-1]
+    expected_text = (
+        test.test_data.expected_text if test.test_data.expected_text is not None else test.test_data.llm_responses[-1]
+    )
     expected_text = expected_text.content if isinstance(expected_text, AIMessage) else expected_text
 
     assert (
@@ -566,7 +569,7 @@ async def test_streaming(test: RedboxChatTestCase, env: Settings, mocker: Mocker
     assert (
         final_state["text"] == expected_text
     ), f"Expected text: '{expected_text}' did not match received text '{final_state["text"]}'"
-    
+
     assert (
         final_state.get("route_name") == test_case.test_data.expected_route
     ), f"Expected Route: '{ test_case.test_data.expected_route}'. Received '{final_state["route_name"]}'"


### PR DESCRIPTION
## Context

feature/citation_prompt has turned off streaming for citation responses temporarily. This restores it.

This PR should wait until the db migration fix PR has gone in. There should be no issues either way though

## Changes proposed in this pull request

A custom PydanticOutputParser which streams tokens from the answer field of our citation response class while maintaining the creation of the pydantic object which tracks the answer and citations

## Guidance to review

Enjoy. The work is mostly based on the existing Langchain output parsers with the relevant _transform functions overridden to allow stateful tracking of the token deltas. 


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
