### PR TITLE
Using filename passed from django app as uri in elastic model

### DIFF
--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -268,7 +268,7 @@ class UnstructuredChunkLoader:
                 page_content=raw_chunk["text"],
                 metadata=UploadedFileMetadata(
                     index=i,
-                    uri=raw_chunk["metadata"].get("filename"),
+                    uri=file_name,
                     page_number=raw_chunk["metadata"].get("page_number"),
                     created_datetime=datetime.now(UTC),
                     token_count=len(encoding.encode(raw_chunk["text"])),


### PR DESCRIPTION
## Context

Elastic chunks aren't being hit by queries during search, the filenames don't have the new email prefix

## Changes proposed in this pull request

Use the filename from the django app as the chunk uri (was filename). This matches what's used at query time


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests https://github.com/i-dot-ai/redbox/actions/runs/11576609019
