### PR TITLE
Calculating tokens from raw LLM response

### DIFF
--- a/redbox-core/redbox/chains/runnables.py
+++ b/redbox-core/redbox/chains/runnables.py
@@ -140,11 +140,13 @@ def build_llm_chain(
             "metadata": (
                 {
                     "prompt": itemgetter("prompt"),
-                    "response": combine_getters(itemgetter("text_and_tools"), itemgetter("raw_response"), attrgetter("content")),
+                    "response": combine_getters(
+                        itemgetter("text_and_tools"), itemgetter("raw_response"), attrgetter("content")
+                    ),
                     "model": lambda _: model_name,
                 }
                 | to_request_metadata
-            )
+            ),
         }
     )
 

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -180,7 +180,10 @@ class RequestMetadata(BaseModel):
     number_of_selected_files: int = 0
 
     @property
-    def input_tokens(self):
+    def input_tokens(self) -> dict[str, int]:
+        """
+        Creates a dictionary of model names to number of input tokens used
+        """
         tokens_by_model = dict()
         for call_metadata in self.llm_calls:
             tokens_by_model[call_metadata.llm_model_name] = (
@@ -190,6 +193,9 @@ class RequestMetadata(BaseModel):
 
     @property
     def output_tokens(self):
+        """
+        Creates a dictionary of model names to number of output tokens used
+        """
         tokens_by_model = dict()
         for call_metadata in self.llm_calls:
             tokens_by_model[call_metadata.llm_model_name] = (


### PR DESCRIPTION

## Context

When using a custom output parser (as in agentic search), we're not accounts for the full number of output tokens in metadata

## Changes proposed in this pull request

Pass the raw response through to the metadata calculation to restore accurate counts

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
