### PR TITLE
Add waitlist link to homepage (when auto sign-ups are off)

### DIFF
--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -36,7 +36,7 @@
                         {% endif %}
                     </div>
                     {% if not request.user.is_authenticated and not allow_sign_ups %}
-                        <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-5">We are not currently allowing new users to sign up. Please check back soon.</p>
+                        <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-5">We have paused new users signing up to Redbox. Please add your email to the <a href="https://docs.google.com/forms/d/e/1FAIpQLSev6KZ6ASgz54GKINfk18k_Ygo_hZxcuQrS3v5XzWc4DE1gaw/viewform?usp=sharing">waitlist</a>.</p>
                     {% endif %}
                 {% endif %}
                 


### PR DESCRIPTION
## Context

Adding a waitlist link to the homepage (when automatic sign-ups are off), and making the text friendlier.


## Guidance to review

* Set `ALLOW_SIGN_UPS` to `False` in your `.env`.
* Check the link works, and the text reads okay


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
