### PR TITLE
Chore/tidy models

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -36,10 +36,8 @@ from redbox_app.redbox_core.models import (
     ChatLLMBackend,
     ChatMessage,
     ChatMessageTokenUse,
-    ChatRoleEnum,
     Citation,
     File,
-    StatusEnum,
 )
 from redbox_app.redbox_core.models import AISettings as AISettingsModel
 
@@ -107,7 +105,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
             )
 
         # save user message
-        permitted_files = File.objects.filter(user=user, status=StatusEnum.complete)
+        permitted_files = File.objects.filter(user=user, status=File.StatusEnum.complete)
         selected_files = permitted_files.filter(id__in=selected_file_uuids)
         await self.save_user_message(session, user_message_text, selected_files=selected_files)
 
@@ -185,7 +183,12 @@ class ChatConsumer(AsyncWebsocketConsumer):
         user_message_text: str,
         selected_files: Sequence[File] | None = None,
     ) -> ChatMessage:
-        chat_message = ChatMessage(chat=session, text=user_message_text, role=ChatRoleEnum.user, route=self.route)
+        chat_message = ChatMessage(
+            chat=session,
+            text=user_message_text,
+            role=ChatMessage.ChatRoleEnum.user,
+            route=self.route,
+        )
         chat_message.save()
         if selected_files:
             chat_message.selected_files.set(selected_files)
@@ -197,7 +200,12 @@ class ChatConsumer(AsyncWebsocketConsumer):
         session: Chat,
         user_message_text: str,
     ) -> ChatMessage:
-        chat_message = ChatMessage(chat=session, text=user_message_text, role=ChatRoleEnum.ai, route=self.route)
+        chat_message = ChatMessage(
+            chat=session,
+            text=user_message_text,
+            role=ChatMessage.ChatRoleEnum.ai,
+            route=self.route,
+        )
         chat_message.save()
         for file, ai_citation in self.citations:
             for citation_source in ai_citation.sources:

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -105,7 +105,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
             )
 
         # save user message
-        permitted_files = File.objects.filter(user=user, status=File.StatusEnum.complete)
+        permitted_files = File.objects.filter(user=user, status=File.Status.complete)
         selected_files = permitted_files.filter(id__in=selected_file_uuids)
         await self.save_user_message(session, user_message_text, selected_files=selected_files)
 
@@ -186,7 +186,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
         chat_message = ChatMessage(
             chat=session,
             text=user_message_text,
-            role=ChatMessage.ChatRoleEnum.user,
+            role=ChatMessage.Role.user,
             route=self.route,
         )
         chat_message.save()
@@ -203,7 +203,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
         chat_message = ChatMessage(
             chat=session,
             text=user_message_text,
-            role=ChatMessage.ChatRoleEnum.ai,
+            role=ChatMessage.Role.ai,
             route=self.route,
         )
         chat_message.save()
@@ -234,14 +234,14 @@ class ChatConsumer(AsyncWebsocketConsumer):
             for model, token_count in self.metadata.input_tokens.items():
                 ChatMessageTokenUse.objects.create(
                     chat_message=chat_message,
-                    use_type=ChatMessageTokenUse.UseTypeEnum.INPUT,
+                    use_type=ChatMessageTokenUse.UseType.INPUT,
                     model_name=model,
                     token_count=token_count,
                 )
             for model, token_count in self.metadata.output_tokens.items():
                 ChatMessageTokenUse.objects.create(
                     chat_message=chat_message,
-                    use_type=ChatMessageTokenUse.UseTypeEnum.OUTPUT,
+                    use_type=ChatMessageTokenUse.UseType.OUTPUT,
                     model_name=model,
                     token_count=token_count,
                 )

--- a/django_app/redbox_app/redbox_core/management/commands/delete_expired_data.py
+++ b/django_app/redbox_app/redbox_core/management/commands/delete_expired_data.py
@@ -61,16 +61,16 @@ class Command(BaseCommand):
 
                 except BotoCoreError as e:
                     logger.exception("Error deleting file object %s from storage", file, exc_info=e)
-                    file.status = File.StatusEnum.errored
+                    file.status = File.Status.errored
                     file.save()
                     failure_counter += 1
                 except Exception as e:
                     logger.exception("Error deleting file object %s", file, exc_info=e)
-                    file.status = File.StatusEnum.errored
+                    file.status = File.Status.errored
                     file.save()
                     failure_counter += 1
                 else:
-                    file.status = File.StatusEnum.deleted
+                    file.status = File.Status.deleted
                     file.save()
                     logger.debug("File object %s deleted", file)
 

--- a/django_app/redbox_app/redbox_core/management/commands/delete_expired_data.py
+++ b/django_app/redbox_app/redbox_core/management/commands/delete_expired_data.py
@@ -11,7 +11,7 @@ from django.db.models import Max
 from django.utils import timezone
 from requests.exceptions import RequestException
 
-from redbox_app.redbox_core.models import INACTIVE_STATUSES, Chat, File, StatusEnum
+from redbox_app.redbox_core.models import Chat, File
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class Command(BaseCommand):
             counter = 0
             failure_counter = 0
 
-            for file in File.objects.filter(last_referenced__lt=cutoff_date).exclude(status__in=INACTIVE_STATUSES):
+            for file in File.objects.filter(last_referenced__lt=cutoff_date).exclude(status__in=File.INACTIVE_STATUSES):
                 logger.debug(
                     "Deleting file object %s, last_referenced %s",
                     file,
@@ -61,16 +61,16 @@ class Command(BaseCommand):
 
                 except BotoCoreError as e:
                     logger.exception("Error deleting file object %s from storage", file, exc_info=e)
-                    file.status = StatusEnum.errored
+                    file.status = File.StatusEnum.errored
                     file.save()
                     failure_counter += 1
                 except Exception as e:
                     logger.exception("Error deleting file object %s", file, exc_info=e)
-                    file.status = StatusEnum.errored
+                    file.status = File.StatusEnum.errored
                     file.save()
                     failure_counter += 1
                 else:
-                    file.status = StatusEnum.deleted
+                    file.status = File.StatusEnum.deleted
                     file.save()
                     logger.debug("File object %s deleted", file)
 

--- a/django_app/redbox_app/redbox_core/management/commands/reingest_files.py
+++ b/django_app/redbox_app/redbox_core/management/commands/reingest_files.py
@@ -5,7 +5,7 @@ from django.core.management import BaseCommand
 from django_q.tasks import async_task
 
 from redbox.models import Settings
-from redbox_app.redbox_core.models import INACTIVE_STATUSES, File
+from redbox_app.redbox_core.models import File
 from redbox_app.worker import ingest
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ class Command(BaseCommand):
 
         new_index = f"{env.elastic_root_index}-chunk-{int(time.time())}"
 
-        for file in File.objects.exclude(status__in=INACTIVE_STATUSES):
+        for file in File.objects.exclude(status__in=File.INACTIVE_STATUSES):
             logger.debug("Reingesting file object %s", file)
             async_task(
                 ingest,

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -5,7 +5,6 @@ from collections.abc import Collection, Sequence
 from datetime import UTC, date, datetime, timedelta
 from typing import override
 
-import jwt
 from django.conf import settings
 from django.contrib.auth.base_user import BaseUserManager as BaseSSOUserManager
 from django.contrib.postgres.fields import ArrayField
@@ -514,12 +513,6 @@ class User(BaseUser, UUIDPrimaryKeyBase):
         self.email = self.email.lower()
         super().save(*args, **kwargs)
 
-    def get_bearer_token(self) -> str:
-        """the bearer token expected by the core-api"""
-        user_uuid = str(self.id)
-        bearer_token = jwt.encode({"user_uuid": user_uuid}, key=settings.SECRET_KEY)
-        return f"Bearer {bearer_token}"
-
     def get_initials(self) -> str:
         try:
             if self.name:
@@ -534,16 +527,6 @@ class User(BaseUser, UUIDPrimaryKeyBase):
             return first_name[0].upper() + last_name[0].upper()
         except (IndexError, AttributeError, ValueError):
             return ""
-
-
-class StatusEnum(models.TextChoices):
-    complete = "complete"
-    deleted = "deleted"
-    errored = "errored"
-    processing = "processing"
-
-
-INACTIVE_STATUSES = [StatusEnum.deleted, StatusEnum.errored]
 
 
 class InactiveFileError(ValueError):
@@ -561,6 +544,14 @@ def build_s3_key(instance, filename: str) -> str:
 
 
 class File(UUIDPrimaryKeyBase, TimeStampedModel):
+    class StatusEnum(models.TextChoices):
+        complete = "complete"
+        deleted = "deleted"
+        errored = "errored"
+        processing = "processing"
+
+    INACTIVE_STATUSES = [StatusEnum.deleted, StatusEnum.errored]
+
     status = models.CharField(choices=StatusEnum.choices, null=False, blank=False)
     original_file = models.FileField(
         storage=settings.STORAGES["default"]["BACKEND"],
@@ -629,14 +620,14 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     @property
     def unique_name(self) -> str:
         """primary key for accessing file in s3"""
-        if self.status in INACTIVE_STATUSES:
+        if self.status in self.INACTIVE_STATUSES:
             logger.exception("Attempt to access s3-key for inactive file %s with status %s", self.pk, self.status)
             raise InactiveFileError(self)
         return self.original_file.name
 
     def get_status_text(self) -> str:
         return next(
-            (status[1] for status in StatusEnum.choices if self.status == status[0]),
+            (status[1] for status in self.StatusEnum.choices if self.status == status[0]),
             "Unknown",
         )
 
@@ -655,8 +646,8 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     def get_completed_and_processing_files(cls, user: User) -> tuple[Sequence["File"], Sequence["File"]]:
         """Returns all files that are completed and processing for a given user."""
 
-        completed_files = cls.objects.filter(user=user, status=StatusEnum.complete).order_by("-created_at")
-        processing_files = cls.objects.filter(user=user, status=StatusEnum.processing).order_by("-created_at")
+        completed_files = cls.objects.filter(user=user, status=cls.StatusEnum.complete).order_by("-created_at")
+        processing_files = cls.objects.filter(user=user, status=cls.StatusEnum.processing).order_by("-created_at")
         return completed_files, processing_files
 
     @classmethod
@@ -729,12 +720,6 @@ class Chat(UUIDPrimaryKeyBase, TimeStampedModel, AbstractAISettings):
         return get_date_group(self.newest_message_date)
 
 
-class ChatRoleEnum(models.TextChoices):
-    ai = "ai"
-    user = "user"
-    system = "system"
-
-
 class Citation(UUIDPrimaryKeyBase, TimeStampedModel):
     class Origin(models.TextChoices):
         WIKIPEDIA = "Wikipedia", _("wikipedia")
@@ -798,6 +783,11 @@ class Citation(UUIDPrimaryKeyBase, TimeStampedModel):
 
 
 class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
+    class ChatRoleEnum(models.TextChoices):
+        ai = "ai"
+        user = "user"
+        system = "system"
+
     chat = models.ForeignKey(Chat, on_delete=models.CASCADE)
     text = models.TextField(max_length=32768, null=False, blank=False)
     role = models.CharField(choices=ChatRoleEnum.choices, null=False, blank=False)

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -551,15 +551,15 @@ def build_s3_key(instance, filename: str) -> str:
 
 
 class File(UUIDPrimaryKeyBase, TimeStampedModel):
-    class StatusEnum(models.TextChoices):
+    class Status(models.TextChoices):
         complete = "complete"
         deleted = "deleted"
         errored = "errored"
         processing = "processing"
 
-    INACTIVE_STATUSES = [StatusEnum.deleted, StatusEnum.errored]
+    INACTIVE_STATUSES = [Status.deleted, Status.errored]
 
-    status = models.CharField(choices=StatusEnum.choices, null=False, blank=False)
+    status = models.CharField(choices=Status.choices, null=False, blank=False)
     original_file = models.FileField(
         storage=settings.STORAGES["default"]["BACKEND"],
         upload_to=build_s3_key,
@@ -634,7 +634,7 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
 
     def get_status_text(self) -> str:
         return next(
-            (status[1] for status in File.StatusEnum.choices if self.status == status[0]),
+            (status[1] for status in File.Status.choices if self.status == status[0]),
             "Unknown",
         )
 
@@ -653,8 +653,8 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     def get_completed_and_processing_files(cls, user: User) -> tuple[Sequence["File"], Sequence["File"]]:
         """Returns all files that are completed and processing for a given user."""
 
-        completed_files = cls.objects.filter(user=user, status=File.StatusEnum.complete).order_by("-created_at")
-        processing_files = cls.objects.filter(user=user, status=File.StatusEnum.processing).order_by("-created_at")
+        completed_files = cls.objects.filter(user=user, status=File.Status.complete).order_by("-created_at")
+        processing_files = cls.objects.filter(user=user, status=File.Status.processing).order_by("-created_at")
         return completed_files, processing_files
 
     @classmethod
@@ -790,14 +790,14 @@ class Citation(UUIDPrimaryKeyBase, TimeStampedModel):
 
 
 class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
-    class ChatRoleEnum(models.TextChoices):
+    class Role(models.TextChoices):
         ai = "ai"
         user = "user"
         system = "system"
 
     chat = models.ForeignKey(Chat, on_delete=models.CASCADE)
     text = models.TextField(max_length=32768, null=False, blank=False)
-    role = models.CharField(choices=ChatRoleEnum.choices, null=False, blank=False)
+    role = models.CharField(choices=Role.choices, null=False, blank=False)
     route = models.CharField(max_length=25, null=True, blank=True)
     selected_files = models.ManyToManyField(File, related_name="+", symmetrical=False, blank=True)
     source_files = models.ManyToManyField(File, through=Citation)
@@ -841,16 +841,16 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
 
 
 class ChatMessageTokenUse(UUIDPrimaryKeyBase, TimeStampedModel):
-    class UseTypeEnum(models.TextChoices):
+    class UseType(models.TextChoices):
         INPUT = "input", _("input")
         OUTPUT = "output", _("output")
 
     chat_message = models.ForeignKey(ChatMessage, on_delete=models.CASCADE)
     use_type = models.CharField(
         max_length=10,
-        choices=UseTypeEnum,
+        choices=UseType,
         help_text="input or output tokens",
-        default=UseTypeEnum.INPUT,
+        default=UseType.INPUT,
     )
     model_name = models.CharField(max_length=50, null=True, blank=True)
     token_count = models.PositiveIntegerField(null=True, blank=True)

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -78,7 +78,7 @@ class ChatsView(View):
     @staticmethod
     def decorate_selected_files(all_files: Sequence[File], messages: Sequence[ChatMessage]) -> None:
         if messages:
-            last_user_message = [m for m in messages if m.role == ChatMessage.ChatRoleEnum.user][-1]
+            last_user_message = [m for m in messages if m.role == ChatMessage.Role.user][-1]
             selected_files: Sequence[File] = last_user_message.selected_files.all() or []
         else:
             selected_files = []

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -16,7 +16,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from yarl import URL
 
-from redbox_app.redbox_core.models import Chat, ChatLLMBackend, ChatMessage, ChatRoleEnum, File
+from redbox_app.redbox_core.models import Chat, ChatLLMBackend, ChatMessage, File
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ class ChatsView(View):
     @staticmethod
     def decorate_selected_files(all_files: Sequence[File], messages: Sequence[ChatMessage]) -> None:
         if messages:
-            last_user_message = [m for m in messages if m.role == ChatRoleEnum.user][-1]
+            last_user_message = [m for m in messages if m.role == ChatMessage.ChatRoleEnum.user][-1]
             selected_files: Sequence[File] = last_user_message.selected_files.all() or []
         else:
             selected_files = []

--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -134,7 +134,7 @@ class UploadView(View):
         try:
             logger.info("getting file from s3")
             file = File.objects.create(
-                status=File.StatusEnum.processing.value,
+                status=File.Status.processing.value,
                 user=user,
                 original_file=uploaded_file,
             )
@@ -156,12 +156,12 @@ def remove_doc_view(request, doc_id: uuid):
         except Exception as e:
             logger.exception("Error deleting file object %s.", file, exc_info=e)
             errors.append("There was an error deleting this file")
-            file.status = File.StatusEnum.errored
+            file.status = File.Status.errored
             file.save()
         else:
             logger.info("Removing document: %s", request.POST["doc_id"])
             file.delete_from_s3()
-            file.status = File.StatusEnum.deleted
+            file.status = File.Status.deleted
             file.save()
             return redirect("documents")
 
@@ -178,10 +178,10 @@ def file_status_api_view(request: HttpRequest) -> JsonResponse:
     file_id = request.GET.get("id", None)
     if not file_id:
         logger.error("Error getting file object information - no file ID provided %s.")
-        return JsonResponse({"status": File.StatusEnum.errored.label})
+        return JsonResponse({"status": File.Status.errored.label})
     try:
         file: File = get_object_or_404(File, id=file_id)
     except File.DoesNotExist as ex:
         logger.exception("File object information not found in django - file does not exist %s.", file_id, exc_info=ex)
-        return JsonResponse({"status": File.StatusEnum.errored.label})
+        return JsonResponse({"status": File.Status.errored.label})
     return JsonResponse({"status": file.get_status_text()})

--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -15,7 +15,7 @@ from django.views import View
 from django.views.decorators.http import require_http_methods
 from django_q.tasks import async_task
 
-from redbox_app.redbox_core.models import File, StatusEnum
+from redbox_app.redbox_core.models import File
 from redbox_app.worker import ingest
 
 User = get_user_model()
@@ -134,7 +134,7 @@ class UploadView(View):
         try:
             logger.info("getting file from s3")
             file = File.objects.create(
-                status=StatusEnum.processing.value,
+                status=File.StatusEnum.processing.value,
                 user=user,
                 original_file=uploaded_file,
             )
@@ -156,12 +156,12 @@ def remove_doc_view(request, doc_id: uuid):
         except Exception as e:
             logger.exception("Error deleting file object %s.", file, exc_info=e)
             errors.append("There was an error deleting this file")
-            file.status = StatusEnum.errored
+            file.status = File.StatusEnum.errored
             file.save()
         else:
             logger.info("Removing document: %s", request.POST["doc_id"])
             file.delete_from_s3()
-            file.status = StatusEnum.deleted
+            file.status = File.StatusEnum.deleted
             file.save()
             return redirect("documents")
 
@@ -178,10 +178,10 @@ def file_status_api_view(request: HttpRequest) -> JsonResponse:
     file_id = request.GET.get("id", None)
     if not file_id:
         logger.error("Error getting file object information - no file ID provided %s.")
-        return JsonResponse({"status": StatusEnum.errored.label})
+        return JsonResponse({"status": File.StatusEnum.errored.label})
     try:
         file: File = get_object_or_404(File, id=file_id)
     except File.DoesNotExist as ex:
         logger.exception("File object information not found in django - file does not exist %s.", file_id, exc_info=ex)
-        return JsonResponse({"status": StatusEnum.errored.label})
+        return JsonResponse({"status": File.StatusEnum.errored.label})
     return JsonResponse({"status": file.get_status_text()})

--- a/django_app/redbox_app/worker.py
+++ b/django_app/redbox_app/worker.py
@@ -9,7 +9,7 @@ env = Settings()
 
 def ingest(file_id: UUID, es_index: str | None = None) -> None:
     # These models need to be loaded at runtime otherwise they can be loaded before they exist
-    from redbox_app.redbox_core.models import File, StatusEnum
+    from redbox_app.redbox_core.models import File
 
     if not es_index:
         es_index = env.elastic_chunk_alias
@@ -19,9 +19,9 @@ def ingest(file_id: UUID, es_index: str | None = None) -> None:
     logging.info("Ingesting file: %s", file)
 
     if error := ingest_file(file.unique_name, es_index):
-        file.status = StatusEnum.errored
+        file.status = File.Status.errored
         file.ingest_error = error
     else:
-        file.status = StatusEnum.complete
+        file.status = File.Status.complete
 
     file.save()

--- a/django_app/tests/conftest.py
+++ b/django_app/tests/conftest.py
@@ -20,10 +20,8 @@ from redbox_app.redbox_core.models import (
     ChatLLMBackend,
     ChatMessage,
     ChatMessageTokenUse,
-    ChatRoleEnum,
     Citation,
     File,
-    StatusEnum,
 )
 
 User = get_user_model()
@@ -159,13 +157,15 @@ def chat(alice: User) -> Chat:
 
 @pytest.fixture()
 def chat_with_message(chat: Chat) -> Chat:
-    ChatMessage.objects.create(chat=chat, text="today", role=ChatRoleEnum.user)
+    ChatMessage.objects.create(chat=chat, text="today", role=ChatMessage.ChatRoleEnum.user)
     return chat
 
 
 @pytest.fixture()
 def chat_message(chat: Chat, uploaded_file: File) -> ChatMessage:
-    chat_message = ChatMessage.objects.create(chat=chat, text="A question?", role=ChatRoleEnum.user, route="A route")
+    chat_message = ChatMessage.objects.create(
+        chat=chat, text="A question?", role=ChatMessage.ChatRoleEnum.user, route="A route"
+    )
     chat_message.source_files.set([uploaded_file])
     return chat_message
 
@@ -175,7 +175,7 @@ def chat_message_with_citation(chat: Chat, uploaded_file: File) -> ChatMessage:
     chat_message = ChatMessage.objects.create(
         chat=chat,
         text="An answer.",
-        role=ChatRoleEnum.ai,
+        role=ChatMessage.ChatRoleEnum.ai,
         rating=3,
         rating_chips=["apple", "pear"],
         rating_text="not bad",
@@ -203,7 +203,7 @@ def uploaded_file(alice: User, original_file: UploadedFile, s3_client) -> File: 
         user=alice,
         original_file=original_file,
         last_referenced=datetime.now(tz=UTC) - timedelta(days=14),
-        status=StatusEnum.processing,
+        status=File.StatusEnum.processing,
     )
     file.save()
     yield file
@@ -218,12 +218,30 @@ def original_file() -> UploadedFile:
 
 @pytest.fixture()
 def chat_with_files(chat: Chat, several_files: Sequence[File]) -> Chat:
-    ChatMessage.objects.create(chat=chat, text="A question?", role=ChatRoleEnum.user)
-    chat_message = ChatMessage.objects.create(chat=chat, text="An answer.", role=ChatRoleEnum.ai, route="search")
+    ChatMessage.objects.create(
+        chat=chat,
+        text="A question?",
+        role=ChatMessage.ChatRoleEnum.user,
+    )
+    chat_message = ChatMessage.objects.create(
+        chat=chat,
+        text="An answer.",
+        role=ChatMessage.ChatRoleEnum.ai,
+        route="search",
+    )
     chat_message.source_files.set(several_files[0::2])
-    chat_message = ChatMessage.objects.create(chat=chat, text="A second question?", role=ChatRoleEnum.user)
+    chat_message = ChatMessage.objects.create(
+        chat=chat,
+        text="A second question?",
+        role=ChatMessage.ChatRoleEnum.user,
+    )
     chat_message.selected_files.set(several_files[0:2])
-    chat_message = ChatMessage.objects.create(chat=chat, text="A second answer.", role=ChatRoleEnum.ai, route="search")
+    chat_message = ChatMessage.objects.create(
+        chat=chat,
+        text="A second answer.",
+        role=ChatMessage.ChatRoleEnum.ai,
+        route="search",
+    )
     chat_message.source_files.set([several_files[2]])
     return chat
 
@@ -239,14 +257,30 @@ def user_with_chats_with_messages_over_time(alice: User) -> User:
             Chat.objects.create(id=uuid.uuid4(), user=alice, name="yesterday"),
             Chat.objects.create(id=uuid.uuid4(), user=alice, name="today"),
         ]
-        ChatMessage.objects.create(chat=chats[0], text="40 days old", role=ChatRoleEnum.user)
+        ChatMessage.objects.create(
+            chat=chats[0],
+            text="40 days old",
+            role=ChatMessage.ChatRoleEnum.user,
+        )
     with freeze_time(now - timedelta(days=20)):
-        ChatMessage.objects.create(chat=chats[1], text="20 days old", role=ChatRoleEnum.user)
+        ChatMessage.objects.create(
+            chat=chats[1],
+            text="20 days old",
+            role=ChatMessage.ChatRoleEnum.user,
+        )
     with freeze_time(now - timedelta(days=5)):
-        ChatMessage.objects.create(chat=chats[2], text="5 days old", role=ChatRoleEnum.user)
+        ChatMessage.objects.create(
+            chat=chats[2],
+            text="5 days old",
+            role=ChatMessage.ChatRoleEnum.user,
+        )
     with freeze_time(now - timedelta(days=1)):
-        ChatMessage.objects.create(chat=chats[3], text="yesterday", role=ChatRoleEnum.user)
-    ChatMessage.objects.create(chat=chats[4], text="today", role=ChatRoleEnum.user)
+        ChatMessage.objects.create(
+            chat=chats[3],
+            text="yesterday",
+            role=ChatMessage.ChatRoleEnum.user,
+        )
+    ChatMessage.objects.create(chat=chats[4], text="today", role=ChatMessage.ChatRoleEnum.user)
 
     return alice
 
@@ -260,7 +294,7 @@ def several_files(alice: User, number_to_create: int = 4) -> Sequence[File]:
             File.objects.create(
                 user=alice,
                 original_file=SimpleUploadedFile(filename, b"Lorem Ipsum."),
-                status=StatusEnum.complete,
+                status=File.StatusEnum.complete,
             )
         )
     return files

--- a/django_app/tests/conftest.py
+++ b/django_app/tests/conftest.py
@@ -157,14 +157,14 @@ def chat(alice: User) -> Chat:
 
 @pytest.fixture()
 def chat_with_message(chat: Chat) -> Chat:
-    ChatMessage.objects.create(chat=chat, text="today", role=ChatMessage.ChatRoleEnum.user)
+    ChatMessage.objects.create(chat=chat, text="today", role=ChatMessage.Role.user)
     return chat
 
 
 @pytest.fixture()
 def chat_message(chat: Chat, uploaded_file: File) -> ChatMessage:
     chat_message = ChatMessage.objects.create(
-        chat=chat, text="A question?", role=ChatMessage.ChatRoleEnum.user, route="A route"
+        chat=chat, text="A question?", role=ChatMessage.Role.user, route="A route"
     )
     chat_message.source_files.set([uploaded_file])
     return chat_message
@@ -175,7 +175,7 @@ def chat_message_with_citation(chat: Chat, uploaded_file: File) -> ChatMessage:
     chat_message = ChatMessage.objects.create(
         chat=chat,
         text="An answer.",
-        role=ChatMessage.ChatRoleEnum.ai,
+        role=ChatMessage.Role.ai,
         rating=3,
         rating_chips=["apple", "pear"],
         rating_text="not bad",
@@ -189,10 +189,10 @@ def chat_message_with_citation(chat: Chat, uploaded_file: File) -> ChatMessage:
 def chat_message_with_citation_and_tokens(chat_message_with_citation: ChatMessage) -> ChatMessage:
     chat_message = chat_message_with_citation
     ChatMessageTokenUse.objects.create(
-        chat_message=chat_message, use_type=ChatMessageTokenUse.UseTypeEnum.INPUT, model_name="gpt-4o", token_count=20
+        chat_message=chat_message, use_type=ChatMessageTokenUse.UseType.INPUT, model_name="gpt-4o", token_count=20
     )
     ChatMessageTokenUse.objects.create(
-        chat_message=chat_message, use_type=ChatMessageTokenUse.UseTypeEnum.OUTPUT, model_name="gpt-4o", token_count=200
+        chat_message=chat_message, use_type=ChatMessageTokenUse.UseType.OUTPUT, model_name="gpt-4o", token_count=200
     )
     return chat_message
 
@@ -203,7 +203,7 @@ def uploaded_file(alice: User, original_file: UploadedFile, s3_client) -> File: 
         user=alice,
         original_file=original_file,
         last_referenced=datetime.now(tz=UTC) - timedelta(days=14),
-        status=File.StatusEnum.processing,
+        status=File.Status.processing,
     )
     file.save()
     yield file
@@ -221,25 +221,25 @@ def chat_with_files(chat: Chat, several_files: Sequence[File]) -> Chat:
     ChatMessage.objects.create(
         chat=chat,
         text="A question?",
-        role=ChatMessage.ChatRoleEnum.user,
+        role=ChatMessage.Role.user,
     )
     chat_message = ChatMessage.objects.create(
         chat=chat,
         text="An answer.",
-        role=ChatMessage.ChatRoleEnum.ai,
+        role=ChatMessage.Role.ai,
         route="search",
     )
     chat_message.source_files.set(several_files[0::2])
     chat_message = ChatMessage.objects.create(
         chat=chat,
         text="A second question?",
-        role=ChatMessage.ChatRoleEnum.user,
+        role=ChatMessage.Role.user,
     )
     chat_message.selected_files.set(several_files[0:2])
     chat_message = ChatMessage.objects.create(
         chat=chat,
         text="A second answer.",
-        role=ChatMessage.ChatRoleEnum.ai,
+        role=ChatMessage.Role.ai,
         route="search",
     )
     chat_message.source_files.set([several_files[2]])
@@ -260,27 +260,27 @@ def user_with_chats_with_messages_over_time(alice: User) -> User:
         ChatMessage.objects.create(
             chat=chats[0],
             text="40 days old",
-            role=ChatMessage.ChatRoleEnum.user,
+            role=ChatMessage.Role.user,
         )
     with freeze_time(now - timedelta(days=20)):
         ChatMessage.objects.create(
             chat=chats[1],
             text="20 days old",
-            role=ChatMessage.ChatRoleEnum.user,
+            role=ChatMessage.Role.user,
         )
     with freeze_time(now - timedelta(days=5)):
         ChatMessage.objects.create(
             chat=chats[2],
             text="5 days old",
-            role=ChatMessage.ChatRoleEnum.user,
+            role=ChatMessage.Role.user,
         )
     with freeze_time(now - timedelta(days=1)):
         ChatMessage.objects.create(
             chat=chats[3],
             text="yesterday",
-            role=ChatMessage.ChatRoleEnum.user,
+            role=ChatMessage.Role.user,
         )
-    ChatMessage.objects.create(chat=chats[4], text="today", role=ChatMessage.ChatRoleEnum.user)
+    ChatMessage.objects.create(chat=chats[4], text="today", role=ChatMessage.Role.user)
 
     return alice
 
@@ -294,7 +294,7 @@ def several_files(alice: User, number_to_create: int = 4) -> Sequence[File]:
             File.objects.create(
                 user=alice,
                 original_file=SimpleUploadedFile(filename, b"Lorem Ipsum."),
-                status=File.StatusEnum.complete,
+                status=File.Status.complete,
             )
         )
     return files

--- a/django_app/tests/management/test_commands.py
+++ b/django_app/tests/management/test_commands.py
@@ -216,7 +216,7 @@ def test_reingest_files(uploaded_file: File, requests_mock: Mocker, mocker: Mock
 @pytest.mark.django_db(transaction=True)
 def test_reingest_files_unstructured_fail(uploaded_file: File, requests_mock: Mocker, mocker):
     # Given
-    assert uploaded_file.status == File.Status.StatusEnum.processing
+    assert uploaded_file.status == File.Status.processing
 
     requests_mock.post(
         f"http://{settings.UNSTRUCTURED_HOST}:8000/general/v0/general",

--- a/django_app/tests/management/test_commands.py
+++ b/django_app/tests/management/test_commands.py
@@ -102,7 +102,7 @@ def test_delete_expired_files(uploaded_file: File, last_referenced: datetime, sh
     call_command("delete_expired_data")
 
     # Then
-    is_deleted = File.objects.get(id=mock_file.id).status == File.StatusEnum.deleted
+    is_deleted = File.objects.get(id=mock_file.id).status == File.Status.deleted
     assert is_deleted == should_delete
 
 
@@ -120,7 +120,7 @@ def test_delete_expired_files_with_elastic_error(deletion_mock: MagicMock, uploa
     call_command("delete_expired_data")
 
     # Then
-    assert File.objects.get(id=mock_file.id).status == File.StatusEnum.errored
+    assert File.objects.get(id=mock_file.id).status == File.Status.errored
 
 
 @patch("redbox_app.redbox_core.models.File.delete_from_s3")
@@ -137,7 +137,7 @@ def test_delete_expired_files_with_s3_error(deletion_mock: MagicMock, uploaded_f
     call_command("delete_expired_data")
 
     # Then
-    assert File.objects.get(id=mock_file.id).status == File.StatusEnum.errored
+    assert File.objects.get(id=mock_file.id).status == File.Status.errored
 
 
 @pytest.mark.parametrize(
@@ -156,13 +156,13 @@ def test_delete_expired_chats(chat: Chat, msg_1_date: datetime, msg_2_date: date
         chat_message_1 = ChatMessage.objects.create(
             chat=test_chat,
             text="A question?",
-            role=ChatMessage.ChatRoleEnum.user,
+            role=ChatMessage.Role.user,
         )
     with freeze_time(msg_2_date):
         chat_message_2 = ChatMessage.objects.create(
             chat=test_chat,
             text="A question?",
-            role=ChatMessage.ChatRoleEnum.user,
+            role=ChatMessage.Role.user,
         )
 
     # When
@@ -180,7 +180,7 @@ def test_delete_expired_chats(chat: Chat, msg_1_date: datetime, msg_2_date: date
 @pytest.mark.django_db(transaction=True)
 def test_reingest_files(uploaded_file: File, requests_mock: Mocker, mocker: MockerFixture):
     # Given
-    assert uploaded_file.status == File.StatusEnum.processing
+    assert uploaded_file.status == File.Status.processing
 
     requests_mock.post(
         f"http://{settings.UNSTRUCTURED_HOST}:8000/general/v0/general",
@@ -210,13 +210,13 @@ def test_reingest_files(uploaded_file: File, requests_mock: Mocker, mocker: Mock
 
     # Then
     uploaded_file.refresh_from_db()
-    assert uploaded_file.status == File.StatusEnum.complete
+    assert uploaded_file.status == File.Status.complete
 
 
 @pytest.mark.django_db(transaction=True)
 def test_reingest_files_unstructured_fail(uploaded_file: File, requests_mock: Mocker, mocker):
     # Given
-    assert uploaded_file.status == File.StatusEnum.StatusEnum.processing
+    assert uploaded_file.status == File.Status.StatusEnum.processing
 
     requests_mock.post(
         f"http://{settings.UNSTRUCTURED_HOST}:8000/general/v0/general",
@@ -246,7 +246,7 @@ def test_reingest_files_unstructured_fail(uploaded_file: File, requests_mock: Mo
 
     # Then
     uploaded_file.refresh_from_db()
-    assert uploaded_file.status == File.StatusEnum.StatusEnum.errored
+    assert uploaded_file.status == File.Status.StatusEnum.errored
     assert uploaded_file.ingest_error == "<class 'ValueError'>: Unstructured failed to extract text for this file"
 
 
@@ -277,7 +277,7 @@ def test_update_users(alice: User):
         user=alice,
         original_file=original_file,
         last_referenced=datetime.now(tz=UTC) - timedelta(days=14),
-        status=File.StatusEnum.processing,
+        status=File.Status.processing,
     )
     file.save()
 

--- a/django_app/tests/management/test_commands.py
+++ b/django_app/tests/management/test_commands.py
@@ -246,7 +246,7 @@ def test_reingest_files_unstructured_fail(uploaded_file: File, requests_mock: Mo
 
     # Then
     uploaded_file.refresh_from_db()
-    assert uploaded_file.status == File.Status.StatusEnum.errored
+    assert uploaded_file.status == File.Status.errored
     assert uploaded_file.ingest_error == "<class 'ValueError'>: Unstructured failed to extract text for this file"
 
 

--- a/django_app/tests/management/test_commands.py
+++ b/django_app/tests/management/test_commands.py
@@ -19,7 +19,7 @@ from magic_link.models import MagicLink
 from pytest_mock import MockerFixture
 from requests_mock import Mocker
 
-from redbox_app.redbox_core.models import Chat, ChatMessage, ChatRoleEnum, File, StatusEnum
+from redbox_app.redbox_core.models import Chat, ChatMessage, File
 
 User = get_user_model()
 
@@ -102,7 +102,7 @@ def test_delete_expired_files(uploaded_file: File, last_referenced: datetime, sh
     call_command("delete_expired_data")
 
     # Then
-    is_deleted = File.objects.get(id=mock_file.id).status == StatusEnum.deleted
+    is_deleted = File.objects.get(id=mock_file.id).status == File.StatusEnum.deleted
     assert is_deleted == should_delete
 
 
@@ -120,7 +120,7 @@ def test_delete_expired_files_with_elastic_error(deletion_mock: MagicMock, uploa
     call_command("delete_expired_data")
 
     # Then
-    assert File.objects.get(id=mock_file.id).status == StatusEnum.errored
+    assert File.objects.get(id=mock_file.id).status == File.StatusEnum.errored
 
 
 @patch("redbox_app.redbox_core.models.File.delete_from_s3")
@@ -137,7 +137,7 @@ def test_delete_expired_files_with_s3_error(deletion_mock: MagicMock, uploaded_f
     call_command("delete_expired_data")
 
     # Then
-    assert File.objects.get(id=mock_file.id).status == StatusEnum.errored
+    assert File.objects.get(id=mock_file.id).status == File.StatusEnum.errored
 
 
 @pytest.mark.parametrize(
@@ -153,9 +153,17 @@ def test_delete_expired_chats(chat: Chat, msg_1_date: datetime, msg_2_date: date
     # Given
     test_chat = chat
     with freeze_time(msg_1_date):
-        chat_message_1 = ChatMessage.objects.create(chat=test_chat, text="A question?", role=ChatRoleEnum.user)
+        chat_message_1 = ChatMessage.objects.create(
+            chat=test_chat,
+            text="A question?",
+            role=ChatMessage.ChatRoleEnum.user,
+        )
     with freeze_time(msg_2_date):
-        chat_message_2 = ChatMessage.objects.create(chat=test_chat, text="A question?", role=ChatRoleEnum.user)
+        chat_message_2 = ChatMessage.objects.create(
+            chat=test_chat,
+            text="A question?",
+            role=ChatMessage.ChatRoleEnum.user,
+        )
 
     # When
     call_command("delete_expired_data")
@@ -172,7 +180,7 @@ def test_delete_expired_chats(chat: Chat, msg_1_date: datetime, msg_2_date: date
 @pytest.mark.django_db(transaction=True)
 def test_reingest_files(uploaded_file: File, requests_mock: Mocker, mocker: MockerFixture):
     # Given
-    assert uploaded_file.status == StatusEnum.processing
+    assert uploaded_file.status == File.StatusEnum.processing
 
     requests_mock.post(
         f"http://{settings.UNSTRUCTURED_HOST}:8000/general/v0/general",
@@ -202,13 +210,13 @@ def test_reingest_files(uploaded_file: File, requests_mock: Mocker, mocker: Mock
 
     # Then
     uploaded_file.refresh_from_db()
-    assert uploaded_file.status == StatusEnum.complete
+    assert uploaded_file.status == File.StatusEnum.complete
 
 
 @pytest.mark.django_db(transaction=True)
 def test_reingest_files_unstructured_fail(uploaded_file: File, requests_mock: Mocker, mocker):
     # Given
-    assert uploaded_file.status == StatusEnum.processing
+    assert uploaded_file.status == File.StatusEnum.StatusEnum.processing
 
     requests_mock.post(
         f"http://{settings.UNSTRUCTURED_HOST}:8000/general/v0/general",
@@ -238,7 +246,7 @@ def test_reingest_files_unstructured_fail(uploaded_file: File, requests_mock: Mo
 
     # Then
     uploaded_file.refresh_from_db()
-    assert uploaded_file.status == StatusEnum.errored
+    assert uploaded_file.status == File.StatusEnum.StatusEnum.errored
     assert uploaded_file.ingest_error == "<class 'ValueError'>: Unstructured failed to extract text for this file"
 
 
@@ -269,7 +277,7 @@ def test_update_users(alice: User):
         user=alice,
         original_file=original_file,
         last_referenced=datetime.now(tz=UTC) - timedelta(days=14),
-        status=StatusEnum.processing,
+        status=File.StatusEnum.processing,
     )
     file.save()
 

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -27,9 +27,7 @@ from redbox_app.redbox_core.models import (
     Chat,
     ChatMessage,
     ChatMessageTokenUse,
-    ChatRoleEnum,
     File,
-    StatusEnum,
 )
 
 User = get_user_model()
@@ -85,12 +83,12 @@ async def test_chat_consumer_with_new_session(alice: User, uploaded_file: File, 
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatRoleEnum.user) == ["Hello Hal."]
-    assert await get_chat_message_text(alice, ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
-    assert await get_chat_message_route(alice, ChatRoleEnum.ai) == ["gratitude"]
+    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.user) == ["Hello Hal."]
+    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_route(alice, ChatMessage.ChatRoleEnum.ai) == ["gratitude"]
 
     expected_citations = {("Good afternoon Mr Amor", ()), ("Good afternoon Mr Amor", (34, 35))}
-    assert await get_chat_message_citation_set(alice, ChatRoleEnum.ai) == expected_citations
+    assert await get_chat_message_citation_set(alice, ChatMessage.ChatRoleEnum.ai) == expected_citations
     await refresh_from_db(uploaded_file)
     assert uploaded_file.last_referenced.date() == datetime.now(tz=UTC).date()
 
@@ -131,7 +129,7 @@ async def test_chat_consumer_staff_user(staff_user: User, mocked_connect: Connec
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_route(staff_user, ChatRoleEnum.ai) == ["gratitude"]
+    assert await get_chat_message_route(staff_user, ChatMessage.ChatRoleEnum.ai) == ["gratitude"]
 
 
 @pytest.mark.django_db(transaction=True)
@@ -156,8 +154,8 @@ async def test_chat_consumer_with_existing_session(alice: User, chat: Chat, mock
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatRoleEnum.user) == ["Hello Hal."]
-    assert await get_chat_message_text(alice, ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.user) == ["Hello Hal."]
+    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
 
 
 @pytest.mark.django_db(transaction=True)
@@ -192,9 +190,9 @@ async def test_chat_consumer_with_naughty_question(alice: User, uploaded_file: F
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatRoleEnum.user) == ["Hello Hal. \ufffd"]
-    assert await get_chat_message_text(alice, ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
-    assert await get_chat_message_route(alice, ChatRoleEnum.ai) == ["gratitude"]
+    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.user) == ["Hello Hal. \ufffd"]
+    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_route(alice, ChatMessage.ChatRoleEnum.ai) == ["gratitude"]
     await refresh_from_db(uploaded_file)
     assert uploaded_file.last_referenced.date() == datetime.now(tz=UTC).date()
 
@@ -230,9 +228,9 @@ async def test_chat_consumer_with_naughty_citation(
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatRoleEnum.user) == ["Hello Hal."]
-    assert await get_chat_message_text(alice, ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
-    assert await get_chat_message_route(alice, ChatRoleEnum.ai) == ["gratitude"]
+    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.user) == ["Hello Hal."]
+    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_route(alice, ChatMessage.ChatRoleEnum.ai) == ["gratitude"]
     await refresh_from_db(uploaded_file)
     assert uploaded_file.last_referenced.date() == datetime.now(tz=UTC).date()
 
@@ -269,11 +267,11 @@ async def test_chat_consumer_agentic(alice: User, uploaded_file: File, mocked_co
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatRoleEnum.user) == ["Hello Hal."]
-    assert await get_chat_message_text(alice, ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.user) == ["Hello Hal."]
+    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
 
     expected_citations = {("Good afternoon Mr Amor", ()), ("Good afternoon Mr Amor", (34, 35))}
-    assert await get_chat_message_citation_set(alice, ChatRoleEnum.ai) == expected_citations
+    assert await get_chat_message_citation_set(alice, ChatMessage.ChatRoleEnum.ai) == expected_citations
     await refresh_from_db(uploaded_file)
     assert uploaded_file.last_referenced.date() == datetime.now(tz=UTC).date()
 
@@ -284,12 +282,12 @@ async def test_chat_consumer_agentic(alice: User, uploaded_file: File, mocked_co
 
 
 @database_sync_to_async
-def get_chat_message_text(user: User, role: ChatRoleEnum) -> Sequence[str]:
+def get_chat_message_text(user: User, role: ChatMessage.ChatRoleEnum) -> Sequence[str]:
     return [m.text for m in ChatMessage.objects.filter(chat__user=user, role=role)]
 
 
 @database_sync_to_async
-def get_chat_message_citation_set(user: User, role: ChatRoleEnum) -> Sequence[tuple[str, tuple[int]]]:
+def get_chat_message_citation_set(user: User, role: ChatMessage.ChatRoleEnum) -> Sequence[tuple[str, tuple[int]]]:
     return {
         (citation.text, tuple(citation.page_numbers or []))
         for message in ChatMessage.objects.filter(chat__user=user, role=role)
@@ -299,7 +297,7 @@ def get_chat_message_citation_set(user: User, role: ChatRoleEnum) -> Sequence[tu
 
 
 @database_sync_to_async
-def get_chat_message_route(user: User, role: ChatRoleEnum) -> Sequence[str]:
+def get_chat_message_route(user: User, role: ChatMessage.ChatRoleEnum) -> Sequence[str]:
     return [m.route for m in ChatMessage.objects.filter(chat__user=user, role=role)]
 
 
@@ -364,7 +362,7 @@ async def test_chat_consumer_with_selected_files(
     # TODO (@brunns): Assert selected files saved to model.
     # Requires fix for https://github.com/django/channels/issues/1091
     all_messages = get_chat_messages(alice)
-    last_user_message = [m for m in all_messages if m.rule == ChatRoleEnum.user][-1]
+    last_user_message = [m for m in all_messages if m.rule == ChatMessage.ChatRoleEnum.user][-1]
     assert last_user_message.selected_files == selected_files
 
 
@@ -523,7 +521,7 @@ async def test_chat_consumer_redbox_state(
         selected_file_uuids: Sequence[str] = [str(f.id) for f in selected_files]
         selected_file_keys: Sequence[str] = [f.unique_name for f in selected_files]
         permitted_file_keys: Sequence[str] = [
-            f.unique_name async for f in File.objects.filter(user=alice, status=StatusEnum.complete)
+            f.unique_name async for f in File.objects.filter(user=alice, status=File.StatusEnum.complete)
         ]
         assert selected_file_keys != permitted_file_keys
 

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -83,19 +83,19 @@ async def test_chat_consumer_with_new_session(alice: User, uploaded_file: File, 
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.user) == ["Hello Hal."]
-    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
-    assert await get_chat_message_route(alice, ChatMessage.ChatRoleEnum.ai) == ["gratitude"]
+    assert await get_chat_message_text(alice, ChatMessage.Role.user) == ["Hello Hal."]
+    assert await get_chat_message_text(alice, ChatMessage.Role.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_route(alice, ChatMessage.Role.ai) == ["gratitude"]
 
     expected_citations = {("Good afternoon Mr Amor", ()), ("Good afternoon Mr Amor", (34, 35))}
-    assert await get_chat_message_citation_set(alice, ChatMessage.ChatRoleEnum.ai) == expected_citations
+    assert await get_chat_message_citation_set(alice, ChatMessage.Role.ai) == expected_citations
     await refresh_from_db(uploaded_file)
     assert uploaded_file.last_referenced.date() == datetime.now(tz=UTC).date()
 
-    assert await get_token_use_model(ChatMessageTokenUse.UseTypeEnum.INPUT) == "gpt-4o"
-    assert await get_token_use_model(ChatMessageTokenUse.UseTypeEnum.OUTPUT) == "gpt-4o"
-    assert await get_token_use_count(ChatMessageTokenUse.UseTypeEnum.INPUT) == 123
-    assert await get_token_use_count(ChatMessageTokenUse.UseTypeEnum.OUTPUT) == 1000
+    assert await get_token_use_model(ChatMessageTokenUse.UseType.INPUT) == "gpt-4o"
+    assert await get_token_use_model(ChatMessageTokenUse.UseType.OUTPUT) == "gpt-4o"
+    assert await get_token_use_count(ChatMessageTokenUse.UseType.INPUT) == 123
+    assert await get_token_use_count(ChatMessageTokenUse.UseType.OUTPUT) == 1000
     assert await get_activity_model() == "fish and chips"
 
 
@@ -129,7 +129,7 @@ async def test_chat_consumer_staff_user(staff_user: User, mocked_connect: Connec
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_route(staff_user, ChatMessage.ChatRoleEnum.ai) == ["gratitude"]
+    assert await get_chat_message_route(staff_user, ChatMessage.Role.ai) == ["gratitude"]
 
 
 @pytest.mark.django_db(transaction=True)
@@ -154,8 +154,8 @@ async def test_chat_consumer_with_existing_session(alice: User, chat: Chat, mock
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.user) == ["Hello Hal."]
-    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_text(alice, ChatMessage.Role.user) == ["Hello Hal."]
+    assert await get_chat_message_text(alice, ChatMessage.Role.ai) == ["Good afternoon, Mr. Amor."]
 
 
 @pytest.mark.django_db(transaction=True)
@@ -190,9 +190,9 @@ async def test_chat_consumer_with_naughty_question(alice: User, uploaded_file: F
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.user) == ["Hello Hal. \ufffd"]
-    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
-    assert await get_chat_message_route(alice, ChatMessage.ChatRoleEnum.ai) == ["gratitude"]
+    assert await get_chat_message_text(alice, ChatMessage.Role.user) == ["Hello Hal. \ufffd"]
+    assert await get_chat_message_text(alice, ChatMessage.Role.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_route(alice, ChatMessage.Role.ai) == ["gratitude"]
     await refresh_from_db(uploaded_file)
     assert uploaded_file.last_referenced.date() == datetime.now(tz=UTC).date()
 
@@ -228,9 +228,9 @@ async def test_chat_consumer_with_naughty_citation(
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.user) == ["Hello Hal."]
-    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
-    assert await get_chat_message_route(alice, ChatMessage.ChatRoleEnum.ai) == ["gratitude"]
+    assert await get_chat_message_text(alice, ChatMessage.Role.user) == ["Hello Hal."]
+    assert await get_chat_message_text(alice, ChatMessage.Role.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_route(alice, ChatMessage.Role.ai) == ["gratitude"]
     await refresh_from_db(uploaded_file)
     assert uploaded_file.last_referenced.date() == datetime.now(tz=UTC).date()
 
@@ -267,27 +267,27 @@ async def test_chat_consumer_agentic(alice: User, uploaded_file: File, mocked_co
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.user) == ["Hello Hal."]
-    assert await get_chat_message_text(alice, ChatMessage.ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_text(alice, ChatMessage.Role.user) == ["Hello Hal."]
+    assert await get_chat_message_text(alice, ChatMessage.Role.ai) == ["Good afternoon, Mr. Amor."]
 
     expected_citations = {("Good afternoon Mr Amor", ()), ("Good afternoon Mr Amor", (34, 35))}
-    assert await get_chat_message_citation_set(alice, ChatMessage.ChatRoleEnum.ai) == expected_citations
+    assert await get_chat_message_citation_set(alice, ChatMessage.Role.ai) == expected_citations
     await refresh_from_db(uploaded_file)
     assert uploaded_file.last_referenced.date() == datetime.now(tz=UTC).date()
 
-    assert await get_token_use_model(ChatMessageTokenUse.UseTypeEnum.INPUT) == "gpt-4o"
-    assert await get_token_use_model(ChatMessageTokenUse.UseTypeEnum.OUTPUT) == "gpt-4o"
-    assert await get_token_use_count(ChatMessageTokenUse.UseTypeEnum.INPUT) == 123
-    assert await get_token_use_count(ChatMessageTokenUse.UseTypeEnum.OUTPUT) == 1000
+    assert await get_token_use_model(ChatMessageTokenUse.UseType.INPUT) == "gpt-4o"
+    assert await get_token_use_model(ChatMessageTokenUse.UseType.OUTPUT) == "gpt-4o"
+    assert await get_token_use_count(ChatMessageTokenUse.UseType.INPUT) == 123
+    assert await get_token_use_count(ChatMessageTokenUse.UseType.OUTPUT) == 1000
 
 
 @database_sync_to_async
-def get_chat_message_text(user: User, role: ChatMessage.ChatRoleEnum) -> Sequence[str]:
+def get_chat_message_text(user: User, role: ChatMessage.Role) -> Sequence[str]:
     return [m.text for m in ChatMessage.objects.filter(chat__user=user, role=role)]
 
 
 @database_sync_to_async
-def get_chat_message_citation_set(user: User, role: ChatMessage.ChatRoleEnum) -> Sequence[tuple[str, tuple[int]]]:
+def get_chat_message_citation_set(user: User, role: ChatMessage.Role) -> Sequence[tuple[str, tuple[int]]]:
     return {
         (citation.text, tuple(citation.page_numbers or []))
         for message in ChatMessage.objects.filter(chat__user=user, role=role)
@@ -297,7 +297,7 @@ def get_chat_message_citation_set(user: User, role: ChatMessage.ChatRoleEnum) ->
 
 
 @database_sync_to_async
-def get_chat_message_route(user: User, role: ChatMessage.ChatRoleEnum) -> Sequence[str]:
+def get_chat_message_route(user: User, role: ChatMessage.Role) -> Sequence[str]:
     return [m.route for m in ChatMessage.objects.filter(chat__user=user, role=role)]
 
 
@@ -362,7 +362,7 @@ async def test_chat_consumer_with_selected_files(
     # TODO (@brunns): Assert selected files saved to model.
     # Requires fix for https://github.com/django/channels/issues/1091
     all_messages = get_chat_messages(alice)
-    last_user_message = [m for m in all_messages if m.rule == ChatMessage.ChatRoleEnum.user][-1]
+    last_user_message = [m for m in all_messages if m.rule == ChatMessage.Role.user][-1]
     assert last_user_message.selected_files == selected_files
 
 
@@ -521,7 +521,7 @@ async def test_chat_consumer_redbox_state(
         selected_file_uuids: Sequence[str] = [str(f.id) for f in selected_files]
         selected_file_keys: Sequence[str] = [f.unique_name for f in selected_files]
         permitted_file_keys: Sequence[str] = [
-            f.unique_name async for f in File.objects.filter(user=alice, status=File.StatusEnum.complete)
+            f.unique_name async for f in File.objects.filter(user=alice, status=File.Status.complete)
         ]
         assert selected_file_keys != permitted_file_keys
 

--- a/django_app/tests/test_models.py
+++ b/django_app/tests/test_models.py
@@ -9,7 +9,6 @@ from redbox_app.redbox_core.models import (
     Citation,
     File,
     InactiveFileError,
-    StatusEnum,
     User,
 )
 
@@ -19,7 +18,7 @@ def test_file_model_last_referenced(peter_rabbit, s3_client):  # noqa: ARG001
     mock_file = SimpleUploadedFile("test.txt", b"these are the file contents")
 
     new_file = File.objects.create(
-        status=StatusEnum.processing,
+        status=File.StatusEnum.processing,
         original_file=mock_file,
         user=peter_rabbit,
     )
@@ -41,8 +40,8 @@ def test_file_model_last_referenced(peter_rabbit, s3_client):  # noqa: ARG001
 @pytest.mark.parametrize(
     ("status"),
     [
-        StatusEnum.complete,
-        StatusEnum.processing,
+        File.StatusEnum.complete,
+        File.StatusEnum.processing,
     ],
 )
 @pytest.mark.django_db()
@@ -61,8 +60,8 @@ def test_file_model_unique_name(status: str, peter_rabbit: User, s3_client):  # 
 @pytest.mark.parametrize(
     ("status"),
     [
-        StatusEnum.deleted,
-        StatusEnum.errored,
+        File.StatusEnum.deleted,
+        File.StatusEnum.errored,
     ],
 )
 @pytest.mark.django_db()

--- a/django_app/tests/test_models.py
+++ b/django_app/tests/test_models.py
@@ -18,7 +18,7 @@ def test_file_model_last_referenced(peter_rabbit, s3_client):  # noqa: ARG001
     mock_file = SimpleUploadedFile("test.txt", b"these are the file contents")
 
     new_file = File.objects.create(
-        status=File.StatusEnum.processing,
+        status=File.Status.processing,
         original_file=mock_file,
         user=peter_rabbit,
     )
@@ -40,8 +40,8 @@ def test_file_model_last_referenced(peter_rabbit, s3_client):  # noqa: ARG001
 @pytest.mark.parametrize(
     ("status"),
     [
-        File.StatusEnum.complete,
-        File.StatusEnum.processing,
+        File.Status.complete,
+        File.Status.processing,
     ],
 )
 @pytest.mark.django_db()
@@ -60,8 +60,8 @@ def test_file_model_unique_name(status: str, peter_rabbit: User, s3_client):  # 
 @pytest.mark.parametrize(
     ("status"),
     [
-        File.StatusEnum.deleted,
-        File.StatusEnum.errored,
+        File.Status.deleted,
+        File.Status.errored,
     ],
 )
 @pytest.mark.django_db()

--- a/django_app/tests/views/test_citation_views.py
+++ b/django_app/tests/views/test_citation_views.py
@@ -12,7 +12,6 @@ from django.urls import reverse
 from redbox_app.redbox_core.models import (
     Chat,
     ChatMessage,
-    ChatRoleEnum,
     Citation,
     File,
 )
@@ -26,7 +25,7 @@ logger = logging.getLogger(__name__)
 def test_citations_shown(client: Client, alice: User, chat: Chat, several_files: Sequence[File]):
     # Given
     client.force_login(alice)
-    chat_message = ChatMessage.objects.create(chat=chat, text="Some answer.", role=ChatRoleEnum.ai)
+    chat_message = ChatMessage.objects.create(chat=chat, text="Some answer.", role=ChatMessage.ChatRoleEnum.ai)
 
     Citation.objects.create(file=several_files[0], chat_message=chat_message, text="Citation 1")
     Citation.objects.create(file=several_files[1], chat_message=chat_message, text="Citation 2")

--- a/django_app/tests/views/test_citation_views.py
+++ b/django_app/tests/views/test_citation_views.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def test_citations_shown(client: Client, alice: User, chat: Chat, several_files: Sequence[File]):
     # Given
     client.force_login(alice)
-    chat_message = ChatMessage.objects.create(chat=chat, text="Some answer.", role=ChatMessage.ChatRoleEnum.ai)
+    chat_message = ChatMessage.objects.create(chat=chat, text="Some answer.", role=ChatMessage.Role.ai)
 
     Citation.objects.create(file=several_files[0], chat_message=chat_message, text="Citation 1")
     Citation.objects.create(file=several_files[1], chat_message=chat_message, text="Citation 2")

--- a/django_app/tests/views/test_document_views.py
+++ b/django_app/tests/views/test_document_views.py
@@ -59,7 +59,7 @@ def test_document_upload_status(client, alice, file_pdf_path: Path, s3_client):
         assert response.url == "/documents/"
         assert count_s3_objects(s3_client) == previous_count + 1
         uploaded_file = File.objects.filter(user=alice).order_by("-created_at")[0]
-        assert uploaded_file.status == File.StatusEnum.processing
+        assert uploaded_file.status == File.Status.processing
 
 
 @pytest.mark.django_db()
@@ -146,7 +146,7 @@ def test_remove_doc_view(client: Client, alice: User, file_pdf_path: Path, s3_cl
         client.post(f"/remove-doc/{new_file.id}", {"doc_id": new_file.id})
         assert not file_exists(s3_client, file_name)
         assert count_s3_objects(s3_client) == previous_count
-        assert File.objects.get(id=new_file.id).status == File.StatusEnum.deleted
+        assert File.objects.get(id=new_file.id).status == File.Status.deleted
 
 
 @pytest.mark.django_db()

--- a/django_app/tests/views/test_document_views.py
+++ b/django_app/tests/views/test_document_views.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.test import Client
 from django.urls import reverse
 
-from redbox_app.redbox_core.models import File, StatusEnum
+from redbox_app.redbox_core.models import File
 
 User = get_user_model()
 
@@ -59,7 +59,7 @@ def test_document_upload_status(client, alice, file_pdf_path: Path, s3_client):
         assert response.url == "/documents/"
         assert count_s3_objects(s3_client) == previous_count + 1
         uploaded_file = File.objects.filter(user=alice).order_by("-created_at")[0]
-        assert uploaded_file.status == StatusEnum.processing
+        assert uploaded_file.status == File.StatusEnum.processing
 
 
 @pytest.mark.django_db()
@@ -146,7 +146,7 @@ def test_remove_doc_view(client: Client, alice: User, file_pdf_path: Path, s3_cl
         client.post(f"/remove-doc/{new_file.id}", {"doc_id": new_file.id})
         assert not file_exists(s3_client, file_name)
         assert count_s3_objects(s3_client) == previous_count
-        assert File.objects.get(id=new_file.id).status == StatusEnum.deleted
+        assert File.objects.get(id=new_file.id).status == File.StatusEnum.deleted
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
## Context

As an Engineer I want enums to be standardised:
* they should live within their parent model's name space
* they should not include redundant words like `Enum` in their names

## Changes proposed in this pull request

1. `StatusEnum` -> `File.Status`
2. `INACTIVE_STATUSES` -> `File.INACTIVE_STATUSES`
3. `ChatRoleEnum` -> `ChatMessage.Role`
4. `ChatMessage.UseTypeEnum` -> `ChatMessage.UseType`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
