### PR TITLE
bugfix/added display name to url

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -838,9 +838,15 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
             )
         )
 
-    def unique_citation_uris(self) -> list[str]:
-        """a unique set of URIs for all citations"""
-        return sorted({citation.uri for citation in self.citation_set.all()})
+    def unique_citation_uris(self) -> list[tuple[str, str]]:
+        """a unique set of names and hrefs for all citations"""
+
+        def get_display(citation):
+            if not citation.file:
+                return str(citation.uri)
+            return citation.file.file_name
+
+        return sorted({(get_display(citation), citation.uri) for citation in self.citation_set.all()})
 
 
 class ChatMessageTokenUse(UUIDPrimaryKeyBase, TimeStampedModel):

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -51,9 +51,9 @@
   <h3 class="iai-chat-bubble__sources-heading govuk-heading-s govuk-!-margin-bottom-1">Sources</h3>
   <div class="iai-display-flex-from-desktop">
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-      {% for uri in message.unique_citation_uris() %}
+      {% for display, href in message.unique_citation_uris() %}
       <li class="govuk-!-margin-bottom-0">
-        <a class="iai-chat-bubbles__sources-link govuk-link" href="{{ uri }}">{{ uri }}</a>
+        <a class="iai-chat-bubbles__sources-link govuk-link" href="{{ href }}">{{ display }}</a>
       </li>
       {% endfor %}
     </ul>

--- a/django_app/tests/test_models.py
+++ b/django_app/tests/test_models.py
@@ -160,5 +160,7 @@ def test_unique_citation_uris(chat_message: ChatMessage, uploaded_file: File):
 
     urls = chat_message.unique_citation_uris()
 
-    assert str(urls[0]) == "http://example.com"
-    assert urls[1].parts == ("/", "redbox-storage-dev", "alice@cabinetoffice.gov.uk", "original_file.txt")
+    assert urls[0][0] == "http://example.com"
+    assert urls[0][1] == URL("http://example.com")
+    assert urls[1][0] == "original_file.txt"
+    assert urls[1][1].parts[-1] == "original_file.txt"


### PR DESCRIPTION
## Context

As a User I want a human readable link

## Changes proposed in this pull request

`unique_citation_uris` now returns both the human-readable name for display and the href

## Guidance to review

compare preprod and dev (where this branch is deployed)

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
