### PR TITLE
Add judging criteria to agentic search

### DIFF
--- a/redbox-core/redbox/models/criteria.py
+++ b/redbox-core/redbox/models/criteria.py
@@ -1,0 +1,184 @@
+search_agent_criteria = """
+[
+    {{
+        "criteria": "Relevance",
+        "definition": "",
+        "scores": [
+            {{
+                "value": 1,
+                "definition": "The information is largely irrelevant to the question.",
+                "indicators": [
+                    {{
+                        "indicator": "Most of the key points and data do not relate to the problem at hand."
+                    }},
+                    {{
+                        "indicator": "The information is mostly extraneous or off-topic."
+                    }},
+                ],
+            }},
+            {{
+                "value": 2,
+                "definition": "The information has some relevance but misses many key aspects of the question.",
+                "indicators": [
+                    {{
+                        "indicator": "Only a few points or data are related to the problem."
+                    }},
+                    {{"indicator": "There is significant irrelevant information."}},
+                ],
+            }},
+            {{
+                "value": 3,
+                "definition": "The information is moderately relevant but not comprehensive.",
+                "indicators": [
+                    {{
+                        "indicator": "A fair number of points and data are related to the question, but some key aspects are missing."
+                    }},
+                    {{"indicator": "Some irrelevant information is present."}},
+                ],
+            }},
+            {{
+                "value": 4,
+                "definition": "The information is mostly relevant with minor gaps.",
+                "indicators": [
+                    {{
+                        "indicator": "Most key points and data are directly related to the question."
+                    }},
+                    {{"indicator": "Very little irrelevant information is present."}},
+                ],
+            }},
+            {{
+                "value": 5,
+                "definition": "The information directly and comprehensively addresses the question.",
+                "indicators": [
+                    {{
+                        "indicator": "All key points and data are directly related to the problem at hand."
+                    }},
+                    {{
+                        "indicator": "No extraneous or irrelevant information is present."
+                    }},
+                ],
+            }},
+        ]
+    }},
+    {{
+        "criteria": "Completeness",
+        "definition": "",
+        "scores": [
+            {{
+                "value": 1,
+                "definition": "The information is highly incomplete.",
+                "indicators": [
+                    {{"indicator": "Few parts of the question are answered."}},
+                    {{"indicator": "Major elements and data points are missing."}},
+                ],
+            }},
+            {{
+                "value": 2,
+                "definition": "The information is somewhat incomplete",
+                "indicators": [
+                    {{
+                        "indicator": "Some parts of the question are answered, but significant elements are missing."
+                    }},
+                    {{"indicator": "Many gaps in the data."}},
+                ],
+            }},
+            {{
+                "value": 3,
+                "definition": "The information is moderately complete.",
+                "indicators": [
+                    {{
+                        "indicator": "Many parts of the question are answered, but some important elements are missing."
+                    }},
+                    {{"indicator": "Some gaps in the data."}},
+                ],
+            }},
+            {{
+                "value": 4,
+                "definition": "The information is mostly complete with minor gaps",
+                "indicators": [
+                    {{"indicator": "Most parts of the question are answered."}},
+                    {{
+                        "indicator": "A few minor elements or data points are missing."
+                    }},
+                ],
+            }},
+            {{
+                "value": 5,
+                "definition": "The information fully covers all aspects of the question.",
+                "indicators": [
+                    {{
+                        "indicator": "Every part of the question is answered with no missing elements."
+                    }},
+                    {{
+                        "indicator": "The provided data and points are exhaustive in scope."
+                    }},
+                ],
+            }},
+        ],
+    }},
+    {{
+        "criteria": "Consistency",
+        "definition": "",
+        "scores": [
+            {{
+                "value": 1,
+                "definition": "The information is highly inconsistent with many contradictions.",
+                "indicators": [
+                    {{
+                        "indicator": "Significant discrepancies and conflicting data across sources."
+                    }},
+                    {{
+                        "indicator": "The information does not form a unified narrative."
+                    }},
+                ],
+            }},
+            {{
+                "value": 2,
+                "definition": "The information has some inconsistencies and contradictions.",
+                "indicators": [
+                    {{
+                        "indicator": "Several discrepancies and conflicting data points."
+                    }},
+                    {{
+                        "indicator": "The information forms a somewhat disjointed narrative."
+                    }},
+                ],
+            }},
+            {{
+                "value": 3,
+                "definition": "The information is moderately consistent with some minor contradictions.",
+                "indicators": [
+                    {{
+                        "indicator": "A few discrepancies and minor conflicting data points."
+                    }},
+                    {{
+                        "indicator": "The information forms a mostly coherent narrative."
+                    }},
+                ],
+            }}
+            {{
+                "value": 4,
+                "definition": "The information is mostly consistent with minor issues.",
+                "indicators": [
+                    {{
+                        "indicator": "Very few discrepancies or conflicting data points."
+                    }},
+                    {{"indicator": "The information forms a coherent narrative."}},
+                ],
+            }},
+            {{
+                "value": 5,
+                "definition": "The information is consistent across different documents and tool call results with no contradictions.",
+                "indicators": [
+                    {{
+                        "indicator": "All data points and information are in agreement across sources."
+                    }},
+                    {{
+                        "indicator": "There are no discrepancies or conflicting information."
+                    }},
+                ],
+            }},
+        ],
+    }},
+]
+"""

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -1,6 +1,6 @@
-CHAT_SYSTEM_PROMPT = (
-    "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
-)
+from redbox.models.criteria import search_agent_criteria
+
+CHAT_SYSTEM_PROMPT = "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
 
 
 CHAT_WITH_DOCS_SYSTEM_PROMPT = "You are an AI assistant called Redbox tasked with answering questions on user provided documents and providing information objectively."
@@ -34,21 +34,19 @@ AGENTIC_RETRIEVAL_SYSTEM_PROMPT = (
     "\n"
     "Objective:\n"
     "1. Examine the available documents and tool calls:\n"
-    "- Evaluate whether the current information is sufficient to answer the question.\n"
-    "- Consider the success or failure of previous tool calls based on the data they returned.\n"
-    "- Hypothesise whether new tool calls might bring more valuable information.\n"
-    "\n"
+    "- Evaluate whether the current information is sufficient to answer the question using the following criteria: "
+    + search_agent_criteria
+    + "\n"
     "2. Decide how to proceed:\n"
     "- If additional tool calls are likely to yield useful information, make those calls.\n"
-    "- If the available documents are sufficient to proceed, conclude your response with the "
+    "- If the evaluation score is higher than 4, conclude your response with the "
     "single word 'answer' to trigger the transfer of the data to another system for final answer "
     "generation.\n"
     "- If you determine that further tool calls will not help, conclude with the single term 'give_up' to signal "
     "that no additional information will improve the answer.\n"
     "\n"
-    "Your role is to think deeply before taking any action. Carefully weigh whether new "
-    "information is necessary or helpful. Only take action (call tools, 'give_up', or trigger an "
-    "'answer') after thorough evaluation of the current documents and tool calls."
+    "Only take action (call tools, 'give_up', or trigger an "
+    "'answer') after thorough evaluation of the current documents and tool calls. Return evaluation score."
 )
 
 
@@ -124,9 +122,13 @@ CONDENSE_SYSTEM_PROMPT = (
 
 CHAT_QUESTION_PROMPT = "{question}\n=========\n Response: "
 
-CHAT_WITH_DOCS_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {formatted_documents} \n\n Answer: "
+CHAT_WITH_DOCS_QUESTION_PROMPT = (
+    "Question: {question}. \n\n Documents: \n\n {formatted_documents} \n\n Answer: "
+)
 
-RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
+RETRIEVAL_QUESTION_PROMPT = (
+    "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
+)
 
 AGENTIC_RETRIEVAL_QUESTION_PROMPT = (
     "The following context and previous actions are provided to assist you. \n\n"
@@ -143,6 +145,8 @@ AGENTIC_GIVE_UP_QUESTION_PROMPT = (
     "User question: \n\n {question}"
 )
 
-CHAT_MAP_QUESTION_PROMPT = "Question: {question}. \n Documents: \n {formatted_documents} \n\n Answer: "
+CHAT_MAP_QUESTION_PROMPT = (
+    "Question: {question}. \n Documents: \n {formatted_documents} \n\n Answer: "
+)
 
 CONDENSE_QUESTION_PROMPT = "{question}\n=========\n Standalone question: "

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -1,6 +1,8 @@
 from redbox.models.criteria import search_agent_criteria
 
-CHAT_SYSTEM_PROMPT = "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
+CHAT_SYSTEM_PROMPT = (
+    "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
+)
 
 
 CHAT_WITH_DOCS_SYSTEM_PROMPT = "You are an AI assistant called Redbox tasked with answering questions on user provided documents and providing information objectively."
@@ -122,13 +124,9 @@ CONDENSE_SYSTEM_PROMPT = (
 
 CHAT_QUESTION_PROMPT = "{question}\n=========\n Response: "
 
-CHAT_WITH_DOCS_QUESTION_PROMPT = (
-    "Question: {question}. \n\n Documents: \n\n {formatted_documents} \n\n Answer: "
-)
+CHAT_WITH_DOCS_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {formatted_documents} \n\n Answer: "
 
-RETRIEVAL_QUESTION_PROMPT = (
-    "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
-)
+RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
 
 AGENTIC_RETRIEVAL_QUESTION_PROMPT = (
     "The following context and previous actions are provided to assist you. \n\n"
@@ -145,8 +143,6 @@ AGENTIC_GIVE_UP_QUESTION_PROMPT = (
     "User question: \n\n {question}"
 )
 
-CHAT_MAP_QUESTION_PROMPT = (
-    "Question: {question}. \n Documents: \n {formatted_documents} \n\n Answer: "
-)
+CHAT_MAP_QUESTION_PROMPT = "Question: {question}. \n Documents: \n {formatted_documents} \n\n Answer: "
 
 CONDENSE_QUESTION_PROMPT = "{question}\n=========\n Standalone question: "


### PR DESCRIPTION
## Context

At the moment the prompt in agentic search use 'subjective' language. To control the reliability of the agent, we add more 'objective' criteria to help the agent makes judging/evaluation consistently.

## Changes proposed in this pull request

- Add `search_agent_criteria` in criteria.py
- Update `AGENTIC_RETRIEVAL_SYSTEM_PROMPT` to contain judging criteria.

## Guidance to review

At the moment, I use hard-code to specify the agent decision i.e. `If the evaluation score is higher than 4, then answer'. In the future we might want to add this in ai setting or agent setting.

## Relevant links


## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests (https://github.com/i-dot-ai/redbox/actions/runs/11596767762)
