### PR TITLE
Prevent duplicate sources when streaming

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/sources-list.js
+++ b/django_app/frontend/src/js/web-components/chats/sources-list.js
@@ -12,6 +12,12 @@ class SourcesList extends HTMLElement {
    * @param {string} url
    */
   add = (fileName, url) => {
+
+    // prevent duplicate sources
+    if (this.sources.some((source) => source.fileName === fileName)) {
+      return;
+    }
+
     this.sources.push({
       fileName: fileName,
       url: url,


### PR DESCRIPTION
## Context

A small pre-emptive fix to ensure duplicate sources aren't displayed when streaming. The fix is already in place for server-side-rendering.


## Guidance to review

* Check sources are still displayed when streaming
* Check the code change looks sensible


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
