### PR TITLE
fix broken filenames

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -619,10 +619,11 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
             return self.original_file_name
 
         # could have a stronger (regex?) way of stripping the users email address?
-        if "/" not in self.original_file.name:
-            msg = "expected filename to start with the user's email address"
-            raise ValueError(msg)
-        return self.original_file.name.split("/")[1]
+        if "/" in self.original_file.name:
+            return self.original_file.name.split("/")[1]
+
+        logger.error("expected filename=%s to start with the user's email address", self.original_file.name)
+        return self.original_file.name
 
     @property
     def unique_name(self) -> str:


### PR DESCRIPTION
## Context

As an Admin I want a quick fix to be able to view Files

## Changes proposed in this pull request

rather than raise a ValueError the `file_name` now logs the error and returns the full file name

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links
https://incubator-for-ai.sentry.io/issues/10896727/?alert_rule_id=41345&alert_timestamp=1730384758135&alert_type=email&environment=redbox-prod&notification_uuid=0af6f1ed-2a30-4b77-8aec-efee693ed29e&project=4507651065512016&referrer=alert_email

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
