### PR TITLE
Removed hosts from .env.example; updated dev docs to latest setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,6 @@ DEV_MODE=true
 
 # === Database ===
 
-ELASTIC__HOST=elasticsearch
 ELASTIC__VERSION=8.11.0
 ELASTIC__USER=elastic
 ELASTIC__PASSWORD=redboxpass
@@ -39,7 +38,6 @@ EMBEDDING_OPENAI_API_KEY=
 
 # === Object Storage ===
 
-MINIO_HOST=minio
 MINIO_PORT=9000
 AWS_ACCESS_KEY=minioadmin
 AWS_SECRET_KEY=minioadmin
@@ -61,7 +59,6 @@ POSTGRES_USER=redbox-core
 POSTGRES_DB=redbox-core
 POSTGRES_PASSWORD=insecure
 CONTACT_EMAIL=redbox-support@cabinetoffice.gov.uk
-POSTGRES_HOST=db
 EMAIL_BACKEND_TYPE=CONSOLE
 GOV_NOTIFY_API_KEY=f4k3_k3y
 FROM_EMAIL=test@example.com

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -13,7 +13,7 @@ Currently, we use [poetry](https://python-poetry.org/) to manage our python pack
 
 ## VSCode
 To make use of the VSCode setup open the workspace file .vscode/redbox.code-workspace. This will open the relevant services as roots in a single workspace. The recommended way to use this is:
-* Create a venv in each of the main service directories (core-api, redbox-core, worker) this should be in a directory called _venv_
+* Create a venv in each of the main service directories (redbox-core, django-app) this should be in a directory called _venv_
 * Configure each workspace directory to use it's own venv python interpreter. NB You may need to enter these manually when prompted as _./venv/bin/python_
 
 The tests should then all load separately and use their own env.
@@ -26,12 +26,11 @@ To run the project, create a new file called `.env` and populate this file with 
 
 Typically this involves setting the following variables:
 
-- `AZURE_OPENAI_API_KEY_XX` - Azure OpenAI API key
-- `AZURE_OPENAI_ENDPOINT_XX` - Azure OpenAI API key
-- `OPENAI_API_VESION_XX` - OpenAI API version
+- `AZURE_OPENAI_API_KEY` - Azure OpenAI API key
+- `AZURE_OPENAI_ENDPOINT` - Azure OpenAI API key
+- `OPENAI_API_VESION` - OpenAI API version
 
-where `XX` can be any of `35T`, `4T`, `4O`. Exactly which LLM you use is decided at runtime from,
-so populate the settings that you need.
+It is best to leave hostnames out of the .env file. These are then set manually by vscode tasks or pulled from a deployment .env like .env.test/.env.integration
 
 ### Backend Profiles
 Redbox can use different backends for chat and embeddings, which are used is controlled by env vars. The defaults are currently to use Azure for both chat and embeddings but OpenAI can be used (and pointed to an OpenAI compliant local service).


### PR DESCRIPTION
## Context

There are environment issues setting up Redbox for the first time and making it work in the various configurations

## Changes proposed in this pull request

Remove hostnames from .env.example. In most cases hostnames will be pulled from a deployment level .env ie

.env.test overlaid with .env gives 'localhost' hostnames for unit tests and notebooks
.env.integration overlaid with .env gives docker network hostnames for CI and docker compose
.env alone gives no hostnames for use in vscode tasks which set the hosts manually to localhost for vscode launch configs

## Guidance to review

Does this interfere with other setups?
