### PR TITLE
Activities are collecting across messages

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -77,6 +77,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
         self.citations = []
         self.external_citations = []
         self.route = None
+        self.activities = []
 
         data = json.loads(text_data or bytes_data)
         logger.debug("received %s from browser", data)


### PR DESCRIPTION
## Context

Activity Events are collecting across chat messages leading to all previous events attached to the latest ai message

## Changes proposed in this pull request

Reset the activities list to empty on receive

## Guidance to review

Is this the right fix for the issue? I'm definitely seeing previous activities on chat messages in preprod and this feels like we're building up all events in a websocket session?

Be good to revisit this long running consumer at some point too; for some of the interruptible/user prompting features we might want soon we need a single instance of the redbox graph (rather than per consumer).

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
