### PR TITLE
Log doc name if only one doc selected

### DIFF
--- a/django_app/frontend/src/js/custom-events.md
+++ b/django_app/frontend/src/js/custom-events.md
@@ -7,6 +7,6 @@ Custom events are used for communication between web components. Here is a list 
 | chat-response-start  | /chats                | (none)                                                  | When the streaming connection is opened                                                   |
 | chat-response-end    | /chats                | title: string<br/>session_id: string                    | When the stream "end" event is sent from the server                                       |
 | doc-complete         | /chats<br/>/documents | file-status: HTMLElement                                | When a document status changes to "complete"                                              |
-| selected-docs-change | /chats                | string[] of document IDs                                | When a user selects or deselects a document                                               |
+| selected-docs-change | /chats                | {id: string, name: string}[]                            | When a user selects or deselects a document                                               |
 | stop-streaming       | /chats                | (none)                                                  | When a user presses the stop-streaming button, or an unexpected disconnection has occured |
 | chat-title-change    | /chats                | title: string<br/>session_id: string<br/>sender: string | When the chat title is changed by the user                                                |

--- a/django_app/frontend/src/js/web-components/chats/chat-controller.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-controller.js
@@ -31,6 +31,10 @@ class ChatController extends HTMLElement {
         `You selected ${selectedDocuments.length || "no"} document${selectedDocuments.length === 1 ? "" : "s"}`,
         "You sent this prompt"
       ];
+      // add filename to activity if only one file
+      if (selectedDocuments.length === 1) {
+        activites[0] += ` (${selectedDocuments[0].name})`;
+      }
       activites.forEach((activity) => {
         userMessage.addActivity(activity, "user");
       });
@@ -47,7 +51,7 @@ class ChatController extends HTMLElement {
 
       aiMessage.stream(
         userText,
-        selectedDocuments,
+        selectedDocuments.map(doc => doc.id),
         activites,
         llm,
         this.dataset.sessionId,

--- a/django_app/frontend/src/js/web-components/chats/document-selector.js
+++ b/django_app/frontend/src/js/web-components/chats/document-selector.js
@@ -10,7 +10,10 @@ class DocumentSelector extends HTMLElement {
       let selectedDocuments = [];
       documents.forEach((document) => {
         if (document.checked) {
-          selectedDocuments.push(document.value);
+          selectedDocuments.push({
+            id: document.value,
+            name: this.querySelector(`[for="${document.id}"]`)?.textContent
+          });
         }
       });
       const evt = new CustomEvent("selected-docs-change", {


### PR DESCRIPTION
## Context

Display the name of the selected document for user messages on the activity log.


## Changes proposed in this pull request

* Display the name of the selected document if there is only one document selected.
* If more than one document selected then just display the number of documents, without filenames.
* This behaviour is easy to update at a later date

![image](https://github.com/user-attachments/assets/84e92982-7ba9-48c2-96c2-6538140e80da)


## Guidance to review

* Test with no, 1, and 2+ docs selected


## Relevant links



## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
