### PR TITLE
Added logging to elastic for user messages

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -201,6 +201,8 @@ class ChatConsumer(AsyncWebsocketConsumer):
             activity = ActivityEvent.objects.create(chat_message=chat_message, message=message)
             activity.save()
 
+        chat_message.log()
+
         return chat_message
 
     @database_sync_to_async

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -851,7 +851,7 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
             "user_id": str(self.chat.user.id),
             "text": str(self.text),
             "route": str(self.route),
-            "role": "ai",
+            "role": str(self.role),
             "token_count": token_sum,
             "rating": int(self.rating) if self.rating else None,
             "rating_text": str(self.rating_text),


### PR DESCRIPTION
## Context

We're only logging ai side messages at the minute so we're missing some details

## Changes proposed in this pull request

Add the same logging line to save_user_message so we see both sides of the conversation. Also set the role field from the chat_message.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
