### PR TITLE
Feature/dev with langfuse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ LLM_MAX_TOKENS=1024
 
 DEV_MODE=true
 
+# Langfuse
+LANGFUSE_SECRET_KEY=sk-lf-878345f5-fa2c-46f0-8193-d6be00910ab0
+LANGFUSE_PUBLIC_KEY=pk-lf-6f517f1f-3fd0-4b00-9c2d-e9756132cc11
+LANGFUSE_HOST="http://localhost:3000"
+
 # === Database ===
 
 ELASTIC__VERSION=8.11.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,32 @@ services:
       interval: 1m
       timeout: 20m
       retries: 5
+  langfuse:
+    image: langfuse/langfuse:2
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    networks:
+      - redbox-app-network
+    environment:
+      - DATABASE_URL=postgresql://redbox-core:insecure@db:5432/langfuse
+      - NEXTAUTH_SECRET=mysecret
+      - SALT=mysalt
+      - ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 # generate via `openssl rand -hex 32`
+      - NEXTAUTH_URL=http://localhost:3000
+      - TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-false}
+      - LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES=${LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES:-false}
+      - LANGFUSE_INIT_ORG_ID=${LANGFUSE_INIT_ORG_ID:-Redbox}
+      - LANGFUSE_INIT_ORG_NAME=${LANGFUSE_INIT_ORG_NAME:-Redbox}
+      - LANGFUSE_INIT_PROJECT_ID=${LANGFUSE_INIT_PROJECT_ID:-Redbox}
+      - LANGFUSE_INIT_PROJECT_NAME=${LANGFUSE_INIT_PROJECT_NAME:-Redbox}
+      - LANGFUSE_INIT_PROJECT_PUBLIC_KEY=${LANGFUSE_INIT_PROJECT_PUBLIC_KEY:-pk-lf-6f517f1f-3fd0-4b00-9c2d-e9756132cc11} 
+      - LANGFUSE_INIT_PROJECT_SECRET_KEY=${LANGFUSE_INIT_PROJECT_SECRET_KEY:-sk-lf-878345f5-fa2c-46f0-8193-d6be00910ab0} #For local only
+      - LANGFUSE_INIT_USER_EMAIL=${LANGFUSE_INIT_USER_EMAIL:-me@redbox.localhost}
+      - LANGFUSE_INIT_USER_NAME=${LANGFUSE_INIT_USER_NAME:-me}
+      - LANGFUSE_INIT_USER_PASSWORD=${LANGFUSE_INIT_USER_PASSWORD:-insecure-langfuse}
 
 networks:
   redbox-app-network:

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -123,6 +123,21 @@ We'll need to create a superuser to log in to the Django app, to do this run the
 7. Click that link and you should be logged in.
 
 
+## Running Redbox in a notebook
+
+There are a number of notebooks available, in various states of working! The Redbox core app is able to be created in a notebook and run to allow easy experiementation without the django side.
+agent_experiments.ipynb shows this best currently.
+
+#### Langfuse
+
+When running in a notebook (and again shows in agent_experiments.ipynb) we use a local Langfuse server to record traces. To do this the env vars for Langfuse should be copied out of .env.example into .env:
+``` bash
+LANGFUSE_SECRET_KEY=...
+LANGFUSE_PUBLIC_KEY=...
+LANGFUSE_HOST=...
+```
+The server can be started using docker-compose
+
 ## Pre-commit hooks
 
 - Download and install [pre-commit](https://pre-commit.com) to benefit from pre-commit hooks

--- a/notebooks/agent-experiments.ipynb
+++ b/notebooks/agent-experiments.ipynb
@@ -60,12 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## To use with Langfuse (see docker-compose)\n",
-    "\n",
-    "# Add the below to .env\n",
-    "#LANGFUSE_SECRET_KEY=sk-lf-878345f5-fa2c-46f0-8193-d6be00910ab0\n",
-    "#LANGFUSE_PUBLIC_KEY=pk-lf-6f517f1f-3fd0-4b00-9c2d-e9756132cc11\n",
-    "#LANGFUSE_HOST=\"http://localhost:3000\"\n",
+    "## To use with Langfuse (see DEVELOPER_SETUP)\n",
     "\n",
     "# Uncomment the below to use the langfuse auto-magic configuration to send traces to local langfuse\n",
     "from langfuse.openai import AsyncAzureOpenAI\n"

--- a/notebooks/agent-experiments.ipynb
+++ b/notebooks/agent-experiments.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,25 +29,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:elastic_transport.transport:HEAD http://localhost:9200/_alias/redbox-data-chunk-current [status:200 duration:0.004s]\n",
-      "/Users/james.richards/projects/redbox-copilot/redbox-core/venv/lib/python3.12/site-packages/pydantic/_internal/_generate_schema.py:547: UserWarning: typing.NotRequired is not a Python type (it may be an instance of an object), Pydantic will allow any object with no validation since we cannot even enforce that the input is an instance of the given type. To get rid of this error wrap the type with `pydantic.SkipValidation`.\n",
-      "  warn(\n",
-      "/Users/james.richards/projects/redbox-copilot/redbox-core/venv/lib/python3.12/site-packages/pydantic/_internal/_generate_schema.py:547: UserWarning: typing.NotRequired is not a Python type (it may be an instance of an object), Pydantic will allow any object with no validation since we cannot even enforce that the input is an instance of the given type. To get rid of this error wrap the type with `pydantic.SkipValidation`.\n",
-      "  warn(\n",
-      "/Users/james.richards/projects/redbox-copilot/redbox-core/venv/lib/python3.12/site-packages/pydantic/_internal/_generate_schema.py:547: UserWarning: typing.NotRequired is not a Python type (it may be an instance of an object), Pydantic will allow any object with no validation since we cannot even enforce that the input is an instance of the given type. To get rid of this error wrap the type with `pydantic.SkipValidation`.\n",
-      "  warn(\n",
-      "/Users/james.richards/projects/redbox-copilot/redbox-core/venv/lib/python3.12/site-packages/pydantic/_internal/_generate_schema.py:547: UserWarning: typing.NotRequired is not a Python type (it may be an instance of an object), Pydantic will allow any object with no validation since we cannot even enforce that the input is an instance of the given type. To get rid of this error wrap the type with `pydantic.SkipValidation`.\n",
-      "  warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "app = Redbox(debug=True)"
@@ -55,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,45 +56,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:elastic_transport.transport:POST http://localhost:9200/redbox-data-chunk-current/_search?scroll=5m [status:200 duration:0.002s]\n",
-      "INFO:elastic_transport.transport:DELETE http://localhost:9200/_search/scroll [status:200 duration:0.001s]\n",
-      "/Users/james.richards/projects/redbox-copilot/redbox-core/redbox/chains/components.py:31: LangChainBetaWarning: The function `init_chat_model` is in beta. It is actively being worked on, so the API may change.\n",
-      "  chat_model = init_chat_model(\n",
-      "INFO:httpx:HTTP Request: POST https://oai-i-dot-ai-playground-sweden.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-02-01 \"HTTP/1.1 200 OK\"\n",
-      "INFO:redbox.graph.nodes.processes:Invoking tool _search_wikipedia with args {'query': 'first moon landing date'}\n",
-      "INFO:httpx:HTTP Request: POST https://oai-i-dot-ai-playground-sweden.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-02-01 \"HTTP/1.1 200 OK\"\n",
-      "INFO:httpx:HTTP Request: POST https://oai-i-dot-ai-playground-sweden.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-02-01 \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "**********\n",
-      "\n",
-      "User: @gadget on what day was the first moon landing?\n",
-      "\n",
-      "Activity Log:\n",
-      "\t - You selected no files\n",
-      "\t - Searching Wikipedia for 'first moon landing date'\n",
-      "\t - Reading Wikipedia page Apollo_11\n",
-      "\n",
-      "AI: The first moon landing occurred on July 20, 1969.\n",
-      "\n",
-      "Citations: \n",
-      "The first moon landing occurred on July 20, 1969.\n",
-      "[URL] https://en.wikipedia.org/wiki/Apollo_11\n",
-      "\tCommander Neil Armstrong and Lunar Module Pilot Buzz Aldrin landed the Apollo Lunar Module Eagle on July 20, 1969, at 20:17 UTC\n"
-     ]
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "## To use with Langfuse (see docker-compose)\n",
+    "\n",
+    "# Add the below to .env\n",
+    "#LANGFUSE_SECRET_KEY=sk-lf-878345f5-fa2c-46f0-8193-d6be00910ab0\n",
+    "#LANGFUSE_PUBLIC_KEY=pk-lf-6f517f1f-3fd0-4b00-9c2d-e9756132cc11\n",
+    "#LANGFUSE_HOST=\"http://localhost:3000\"\n",
+    "\n",
+    "# Uncomment the below to use the langfuse auto-magic configuration to send traces to local langfuse\n",
+    "from langfuse.openai import AsyncAzureOpenAI\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "response_text = \"\"\n",

--- a/redbox-core/poetry.lock
+++ b/redbox-core/poetry.lock
@@ -198,6 +198,17 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.3"
 description = "Screen-scraping library"
@@ -2024,6 +2035,31 @@ files = [
 langchain-core = ">=0.3.0,<0.4.0"
 
 [[package]]
+name = "langfuse"
+version = "2.53.9"
+description = "A client library for accessing langfuse"
+optional = false
+python-versions = "<4.0,>=3.8.1"
+files = [
+    {file = "langfuse-2.53.9-py3-none-any.whl", hash = "sha256:04363bc323f7513621c88a997003f7b906ae8f5d096bd54221cfcb6bf7a6f16a"},
+    {file = "langfuse-2.53.9.tar.gz", hash = "sha256:6bfecf86e28c684034ae52a0b19535c94cc86923085267b548d63e5c1ce2b82c"},
+]
+
+[package.dependencies]
+anyio = ">=4.4.0,<5.0.0"
+backoff = ">=1.10.0"
+httpx = ">=0.15.4,<1.0"
+idna = ">=3.7,<4.0"
+packaging = ">=23.2,<25.0"
+pydantic = ">=1.10.7,<3.0"
+wrapt = ">=1.14,<2.0"
+
+[package.extras]
+langchain = ["langchain (>=0.0.309)"]
+llama-index = ["llama-index (>=0.10.12,<2.0.0)"]
+openai = ["openai (>=0.27.8)"]
+
+[[package]]
 name = "langgraph"
 version = "0.2.39"
 description = "Building stateful, multi-actor applications with LLMs"
@@ -3095,19 +3131,6 @@ files = [
     {file = "pyarrow-17.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:392bc9feabc647338e6c89267635e111d71edad5fcffba204425a7c8d13610d7"},
     {file = "pyarrow-17.0.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:af5ff82a04b2171415f1410cff7ebb79861afc5dae50be73ce06d6e870615204"},
     {file = "pyarrow-17.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:edca18eaca89cd6382dfbcff3dd2d87633433043650c07375d095cd3517561d8"},
-    {file = "pyarrow-17.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c7916bff914ac5d4a8fe25b7a25e432ff921e72f6f2b7547d1e325c1ad9d155"},
-    {file = "pyarrow-17.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f553ca691b9e94b202ff741bdd40f6ccb70cdd5fbf65c187af132f1317de6145"},
-    {file = "pyarrow-17.0.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:0cdb0e627c86c373205a2f94a510ac4376fdc523f8bb36beab2e7f204416163c"},
-    {file = "pyarrow-17.0.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:d7d192305d9d8bc9082d10f361fc70a73590a4c65cf31c3e6926cd72b76bc35c"},
-    {file = "pyarrow-17.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:02dae06ce212d8b3244dd3e7d12d9c4d3046945a5933d28026598e9dbbda1fca"},
-    {file = "pyarrow-17.0.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:13d7a460b412f31e4c0efa1148e1d29bdf18ad1411eb6757d38f8fbdcc8645fb"},
-    {file = "pyarrow-17.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9b564a51fbccfab5a04a80453e5ac6c9954a9c5ef2890d1bcf63741909c3f8df"},
-    {file = "pyarrow-17.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32503827abbc5aadedfa235f5ece8c4f8f8b0a3cf01066bc8d29de7539532687"},
-    {file = "pyarrow-17.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a155acc7f154b9ffcc85497509bcd0d43efb80d6f733b0dc3bb14e281f131c8b"},
-    {file = "pyarrow-17.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:dec8d129254d0188a49f8a1fc99e0560dc1b85f60af729f47de4046015f9b0a5"},
-    {file = "pyarrow-17.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:a48ddf5c3c6a6c505904545c25a4ae13646ae1f8ba703c4df4a1bfe4f4006bda"},
-    {file = "pyarrow-17.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:42bf93249a083aca230ba7e2786c5f673507fa97bbd9725a1e2754715151a204"},
-    {file = "pyarrow-17.0.0.tar.gz", hash = "sha256:4beca9521ed2c0921c1023e68d097d0299b62c362639ea315572a58f3f50fd28"},
 ]
 
 [package.dependencies]
@@ -4694,4 +4717,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<3.13"
-content-hash = "fb4b0458b1424bcb1f49a9c9ab85bee2765dcaca495762a42d0187b2571874e2"
+content-hash = "292d34acdef753b394760ffa85824cb9d7dfcfd15ea196ac0df498494754d4ee"

--- a/redbox-core/pyproject.toml
+++ b/redbox-core/pyproject.toml
@@ -39,6 +39,7 @@ deepeval = "^1.0.3"
 pytest-mock = "^3.14.0"
 boto3-stubs = {extras = ["essential"], version = "^1.35.28"}
 requests-mock = "^1.12.1"
+langfuse = "^2.53.9"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Context
Langfuse let's us look at the prompts in a given flow which massively helps us debug issues with prompts/formats etc

## Changes proposed in this pull request
Added langfuse to redbox-core dev dependencies
Added langfuse to the docker-compose (nothing is dependent on it so it's optional)
Added a cell to the agent_experiments notebook to show how to get langfuse running in a notebook. If we decide we want this we can always do this in redbox-core itself (when in dev_mode maybe?) but for now it's opt in in a notebook

## Guidance to review
@MarkDunne thoughts on this approach, did you have other/better ways of setting this up?
The keys in the docker-compose are a one time generation from my local instance, they're not attached to anything and only used locally. We can always switch them out when we pull but it seems handy to have some preconfigured creds.

To use:

docker compose up -d langfuse ( along with the usual, db, elastic ... )
Set the env vars from the commented out cell in the agent_experiments notebook
Run that notebook
Go to localhost:3000 and login with the email and password in the docker-compose INIT vars
See traces
Profit
If we like this approach we should look at team licences etc and discuss more widely