### PR TITLE
feature/added ToolNode

### DIFF
--- a/redbox-core/redbox/api/format.py
+++ b/redbox-core/redbox/api/format.py
@@ -1,8 +1,9 @@
 import json
 
 from langchain_core.documents.base import Document
-from langchain_core.messages import ToolCall
+from langchain_core.messages import AIMessage
 
+from redbox.models.chain import RedboxState
 from redbox.transform import combine_documents
 
 
@@ -38,14 +39,17 @@ def reduce_chunks_by_tokens(chunks: list[Document] | None, chunk: Document, max_
     return chunks
 
 
-def format_toolstate(toolstate: list[ToolCall] | None) -> str:
-    """Takes a toolstate and transforms it into a structure familiar to an LLM."""
-    if not toolstate:
+def format_tool_calls(state: RedboxState) -> str:
+    """Takes a state's last message tool_calls and transforms it into a structure familiar to an LLM."""
+    if not state.messages:
+        return ""
+
+    if not isinstance(state.last_message, AIMessage):
         return ""
 
     formatted_calls: list[str] = []
 
-    for call_info in toolstate:
+    for call_info in state.last_message.tool_calls:
         tool_call = (
             "<ToolCall>\n"
             f"\t<Name>{call_info['name']}</Name>\n"

--- a/redbox-core/redbox/api/format.py
+++ b/redbox-core/redbox/api/format.py
@@ -50,7 +50,6 @@ def format_toolstate(toolstate: ToolState | None) -> str:
             "<ToolCall>\n"
             f"\t<Name>{call_info['tool']['name']}</Name>\n"
             f"\t<Type>{call_info['tool']['type']}</Type>\n"
-            f"\t<Called>{str(call_info['called']).lower()}</Called>\n"
             "\t<Arguments>\n"
             f"{json.dumps(call_info['tool']['args'], indent=2).replace('{', '').replace('}', '').replace('"', '')}\n"
             "\t</Arguments>\n"

--- a/redbox-core/redbox/api/format.py
+++ b/redbox-core/redbox/api/format.py
@@ -48,10 +48,10 @@ def format_toolstate(toolstate: ToolState | None) -> str:
     for call_info in toolstate.values():
         tool_call = (
             "<ToolCall>\n"
-            f"\t<Name>{call_info['tool']['name']}</Name>\n"
-            f"\t<Type>{call_info['tool']['type']}</Type>\n"
+            f"\t<Name>{call_info['name']}</Name>\n"
+            f"\t<Type>{call_info['type']}</Type>\n"
             "\t<Arguments>\n"
-            f"{json.dumps(call_info['tool']['args'], indent=2).replace('{', '').replace('}', '').replace('"', '')}\n"
+            f"{json.dumps(call_info['args'], indent=2).replace('{', '').replace('}', '').replace('"', '')}\n"
             "\t</Arguments>\n"
             "</ToolCall>"
         )

--- a/redbox-core/redbox/api/format.py
+++ b/redbox-core/redbox/api/format.py
@@ -1,8 +1,8 @@
 import json
 
 from langchain_core.documents.base import Document
+from langchain_core.messages import ToolCall
 
-from redbox.models.chain import ToolState
 from redbox.transform import combine_documents
 
 
@@ -38,14 +38,14 @@ def reduce_chunks_by_tokens(chunks: list[Document] | None, chunk: Document, max_
     return chunks
 
 
-def format_toolstate(toolstate: ToolState | None) -> str:
+def format_toolstate(toolstate: list[ToolCall] | None) -> str:
     """Takes a toolstate and transforms it into a structure familiar to an LLM."""
     if not toolstate:
         return ""
 
     formatted_calls: list[str] = []
 
-    for call_info in toolstate.values():
+    for call_info in toolstate:
         tool_call = (
             "<ToolCall>\n"
             f"\t<Name>{call_info['name']}</Name>\n"

--- a/redbox-core/redbox/chains/runnables.py
+++ b/redbox-core/redbox/chains/runnables.py
@@ -11,7 +11,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import Runnable, RunnableGenerator, RunnableLambda, RunnablePassthrough, chain
 from tiktoken import Encoding
 
-from redbox.api.format import format_documents, format_toolstate
+from redbox.api.format import format_documents
 from redbox.chains.activity import log_activity
 from redbox.chains.components import get_tokeniser
 from redbox.models.chain import ChainChatMessage, PromptSet, RedboxState, get_prompts
@@ -69,7 +69,6 @@ def build_chat_prompt_from_messages_runnable(
             | {
                 "messages": state.messages,
                 "formatted_documents": format_documents(flatten_document_state(state.documents)),
-                "tool_calls": format_toolstate(state.tool_calls),
                 "system_info": ai_settings.system_info_prompt,
                 "persona_info": ai_settings.persona_info_prompt,
                 "caller_info": ai_settings.caller_info_prompt,

--- a/redbox-core/redbox/chains/runnables.py
+++ b/redbox-core/redbox/chains/runnables.py
@@ -17,7 +17,7 @@ from redbox.chains.components import get_tokeniser
 from redbox.models.chain import ChainChatMessage, PromptSet, RedboxState, get_prompts
 from redbox.models.errors import QuestionLengthError
 from redbox.models.graph import RedboxEventType
-from redbox.transform import flatten_document_state, get_all_metadata, tool_calls_to_toolstate
+from redbox.transform import flatten_document_state, get_all_metadata
 
 log = logging.getLogger()
 re_string_pattern = re.compile(r"(\S+)")
@@ -108,7 +108,6 @@ def build_llm_chain(
     _llm_text_and_tools = _llm | {
         "raw_response": RunnablePassthrough(),
         "parsed_response": _output_parser,
-        "tool_calls": tool_calls_to_toolstate,
     }
 
     text_and_tools = {

--- a/redbox-core/redbox/chains/runnables.py
+++ b/redbox-core/redbox/chains/runnables.py
@@ -11,7 +11,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import Runnable, RunnableGenerator, RunnableLambda, RunnablePassthrough, chain
 from tiktoken import Encoding
 
-from redbox.api.format import format_documents
+from redbox.api.format import format_documents, format_tool_calls
 from redbox.chains.activity import log_activity
 from redbox.chains.components import get_tokeniser
 from redbox.models.chain import ChainChatMessage, PromptSet, RedboxState, get_prompts
@@ -69,6 +69,7 @@ def build_chat_prompt_from_messages_runnable(
             | {
                 "messages": state.messages,
                 "formatted_documents": format_documents(flatten_document_state(state.documents)),
+                "tool_calls": format_tool_calls(state),
                 "system_info": ai_settings.system_info_prompt,
                 "persona_info": ai_settings.persona_info_prompt,
                 "caller_info": ai_settings.caller_info_prompt,

--- a/redbox-core/redbox/graph/edges.py
+++ b/redbox-core/redbox/graph/edges.py
@@ -96,13 +96,10 @@ def multiple_docs_in_group_conditional(state: RedboxState) -> bool:
     return any(len(group) > 1 for group in state.documents.groups.values())
 
 
-def build_tools_selected_conditional(tools: list[str]) -> Runnable:
+def build_tools_selected_conditional(_tools: list[str]) -> Runnable:
     """Given a list of tools, returns True if any tool is in the state and uncalled."""
 
-    def _tools_selected_conditional(state: RedboxState) -> bool:
-        for tool_call in state.tool_calls.values():
-            if tool_call["tool"]["name"] in tools and not tool_call["called"]:
-                return True
+    def _tools_selected_conditional(_state: RedboxState) -> bool:
         return False
 
     return _tools_selected_conditional

--- a/redbox-core/redbox/graph/edges.py
+++ b/redbox-core/redbox/graph/edges.py
@@ -96,15 +96,6 @@ def multiple_docs_in_group_conditional(state: RedboxState) -> bool:
     return any(len(group) > 1 for group in state.documents.groups.values())
 
 
-def build_tools_selected_conditional(_tools: list[str]) -> Runnable:
-    """Given a list of tools, returns True if any tool is in the state and uncalled."""
-
-    def _tools_selected_conditional(_state: RedboxState) -> bool:
-        return False
-
-    return _tools_selected_conditional
-
-
 def build_strings_end_text_conditional(*strings: str) -> Runnable:
     """Given a list of strings, returns the string if the end of state.last_message.content contains it."""
     pattern = "|".join(re.escape(s) for s in strings)

--- a/redbox-core/redbox/graph/nodes/processes.py
+++ b/redbox-core/redbox/graph/nodes/processes.py
@@ -266,9 +266,8 @@ def build_tool_pattern(
         messages = [
             AIMessage(
                 content="",
-                tool_calls=[tool_call_dict["tool"]],
+                tool_calls=[tool_call_dict["tool"] for tool_call_dict in state.tool_calls.values() or []],
             )
-            for tool_call_dict in state.tool_calls.values() or []
         ]
 
         # Invoke the tool

--- a/redbox-core/redbox/graph/nodes/processes.py
+++ b/redbox-core/redbox/graph/nodes/processes.py
@@ -266,14 +266,14 @@ def build_tool_pattern(
         messages = [
             AIMessage(
                 content="",
-                tool_calls=[tool_call for tool_call in state.tool_calls.values() or []],
+                tool_calls=state.tool_calls,
             )
         ]
 
         # Invoke the tool
         state_update = tool_node.invoke({"messages": messages})
 
-        tool_calls = {tool_id: dict(tool_call, called=True) for tool_id, tool_call in state.tool_calls.items()}
+        tool_calls = state.tool_calls
 
         return reduce(merge_redbox_state_updates, [state_update, {"tool_calls": tool_calls}])
 

--- a/redbox-core/redbox/graph/nodes/processes.py
+++ b/redbox-core/redbox/graph/nodes/processes.py
@@ -266,7 +266,7 @@ def build_tool_pattern(
         messages = [
             AIMessage(
                 content="",
-                tool_calls=[tool_call_dict["tool"] for tool_call_dict in state.tool_calls.values() or []],
+                tool_calls=[tool_call for tool_call in state.tool_calls.values() or []],
             )
         ]
 

--- a/redbox-core/redbox/graph/nodes/sends.py
+++ b/redbox-core/redbox/graph/nodes/sends.py
@@ -50,9 +50,9 @@ def build_tool_send(target: str) -> Callable[[RedboxState], list[Send]]:
         tool_send_states: list[RedboxState] = [
             _copy_state(
                 state,
-                tool_calls={tool_id: tool_call},
+                tool_calls=[tool_call],
             )
-            for tool_id, tool_call in state.tool_calls.items()
+            for tool_call in state.tool_calls
         ]
         return [Send(node=target, arg=state) for state in tool_send_states]
 

--- a/redbox-core/redbox/graph/nodes/sends.py
+++ b/redbox-core/redbox/graph/nodes/sends.py
@@ -1,5 +1,6 @@
 from typing import Callable
 
+from langchain_core.messages import AIMessage
 from langgraph.constants import Send
 
 from redbox.models.chain import DocumentState, RedboxState
@@ -50,9 +51,9 @@ def build_tool_send(target: str) -> Callable[[RedboxState], list[Send]]:
         tool_send_states: list[RedboxState] = [
             _copy_state(
                 state,
-                tool_calls=[tool_call],
+                messages=[AIMessage(content=state.last_message.content, tool_calls=[tool_call])],
             )
-            for tool_call in state.tool_calls
+            for tool_call in state.last_message.tool_calls
         ]
         return [Send(node=target, arg=state) for state in tool_send_states]
 

--- a/redbox-core/redbox/graph/nodes/tools.py
+++ b/redbox-core/redbox/graph/nodes/tools.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Iterable, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, Iterable
 
 import requests
 import tiktoken
@@ -7,7 +7,7 @@ from langchain_community.utilities import WikipediaAPIWrapper
 from langchain_core.documents import Document
 from langchain_core.embeddings.embeddings import Embeddings
 from langchain_core.messages import ToolCall
-from langchain_core.tools import StructuredTool, Tool, tool
+from langchain_core.tools import Tool, tool
 from langgraph.prebuilt import InjectedState
 
 from redbox.models.chain import RedboxState
@@ -22,52 +22,6 @@ from redbox.transform import (
     sort_documents,
     structure_documents_by_group_and_indices,
 )
-
-
-def is_valid_tool(tool: StructuredTool) -> bool:
-    """Checks whether the supplied tool will correctly update the state.
-
-    In Redbox, tools must return a valid state update. Here we enforce they're
-    at least typed to return a dictionary.
-    """
-    return_type = get_type_hints(tool.func).get("return", None)
-
-    if isinstance(return_type, type):
-        return issubclass(return_type, dict)
-
-    # Check for dict with generics (e.g., dict[str, list])
-    if hasattr(return_type, "__origin__") and return_type.__origin__ is dict:
-        key_type, value_type = return_type.__args__
-        if issubclass(key_type, str) and issubclass(value_type, Any):
-            return True
-
-    return False
-
-
-def has_injected_state(tool: StructuredTool) -> bool:
-    """Detects whether the tool has an argument typed with InjectedState.
-
-    Adapted from functions in langgraph.prebuilt.tool_node
-    """
-
-    def _is_injection(type_arg: Any, injection_type: type[InjectedState]) -> bool:
-        """Recursively checks for injection types."""
-        if isinstance(type_arg, injection_type) or (
-            isinstance(type_arg, type) and issubclass(type_arg, injection_type)
-        ):
-            return True
-        origin_ = get_origin(type_arg)
-        if origin_ is Annotated:
-            return any(_is_injection(ta, injection_type) for ta in get_args(type_arg))
-        return False
-
-    full_schema = tool.get_input_schema()
-
-    for type_ in full_schema.__annotations__.values():
-        if _is_injection(type_, InjectedState):
-            return True
-
-    return False
 
 
 def build_search_documents_tool(

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -187,7 +187,7 @@ def get_agentic_search_graph(tools: dict[str, StructuredTool], debug: bool = Fal
         build_activity_log_node(
             lambda s: [
                 RedboxActivityEvent(message=get_log_formatter_for_retrieval_tool(tool_state_entry).log_call())
-                for tool_state_entry in s.tool_calls.values()
+                for tool_state_entry in s.tool_calls
             ]
         ),
     )

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -186,7 +186,7 @@ def get_agentic_search_graph(tools: dict[str, StructuredTool], debug: bool = Fal
         "p_activity_log_retrieval_tool_calls",
         build_activity_log_node(
             lambda s: [
-                RedboxActivityEvent(message=get_log_formatter_for_retrieval_tool(tool_state_entry["tool"]).log_call())
+                RedboxActivityEvent(message=get_log_formatter_for_retrieval_tool(tool_state_entry).log_call())
                 for tool_state_entry in s.tool_calls.values()
             ]
         ),

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -187,7 +187,7 @@ def get_agentic_search_graph(tools: dict[str, StructuredTool], debug: bool = Fal
         build_activity_log_node(
             lambda s: [
                 RedboxActivityEvent(message=get_log_formatter_for_retrieval_tool(tool_state_entry).log_call())
-                for tool_state_entry in s.tool_calls
+                for tool_state_entry in s.last_message.tool_calls
             ]
         ),
     )

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -2,6 +2,7 @@ from langchain_core.tools import StructuredTool
 from langchain_core.vectorstores import VectorStoreRetriever
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.graph import CompiledGraph
+from langgraph.prebuilt import ToolNode
 
 from redbox.chains.components import get_structured_response_with_citations_parser
 from redbox.chains.runnables import build_self_route_output_parser
@@ -24,7 +25,6 @@ from redbox.graph.nodes.processes import (
     build_set_route_pattern,
     build_set_self_route_from_llm_answer,
     build_stuff_pattern,
-    build_tool_pattern,
     clear_documents_process,
     empty_process,
     report_sources_process,
@@ -173,7 +173,7 @@ def get_agentic_search_graph(tools: dict[str, StructuredTool], debug: bool = Fal
     )
     builder.add_node(
         "p_retrieval_tools",
-        build_tool_pattern(tools=agent_tools, final_source_chain=False),
+        ToolNode(tools=agent_tools),
     )
     builder.add_node(
         "p_give_up_agent",

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -242,12 +242,15 @@ def tool_calls_reducer(current: list[ToolCall], update: ToolCall | list[ToolCall
 
     reduced = current.copy()
 
-    _reduced = {v["id"]: ToolCall(**v) for v in reduced}
+    try:
+        _reduced = {v["id"]: ToolCall(**v) for v in reduced}
+    except Exception:
+        raise
 
     if isinstance(update, dict):
         _update = {update["id"]: ToolCall(**update)}
     elif isinstance(update, list):
-        _update = {v["id"]: ToolCall(**v) for v in update}
+        _update = {v["id"]: ToolCall(**v) for v in update if v}
     else:
         raise ValueError
 

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -368,6 +368,8 @@ def merge_redbox_state_updates(current: RedboxState, update: RedboxState) -> Red
                 merged_state[update_key] = dict_reducer(current=current_value or {}, update=update_value or {})
             elif current_value is None:
                 merged_state[update_key] = update_value
+            elif update_value is None:
+                merged_state[update_key] = current_value
             else:
                 # If it's annotated and not a dict, apply its reducer function
                 _, reducer_func = get_args(annotation)

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -230,14 +230,8 @@ def metadata_reducer(
     )
 
 
-class ToolStateEntry(TypedDict):
-    """Represents a single tool call in the ToolState."""
-
-    tool: ToolCall
-
-
 # Represents the state of multiple tools.
-ToolState = dict[str, ToolStateEntry | None]
+ToolState = dict[str, ToolCall | None]
 
 
 def tool_calls_reducer(current: ToolState, update: ToolState | None) -> ToolState:

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -234,7 +234,6 @@ class ToolStateEntry(TypedDict):
     """Represents a single tool call in the ToolState."""
 
     tool: ToolCall
-    called: bool
 
 
 # Represents the state of multiple tools.

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -267,7 +267,6 @@ class RedboxState(BaseModel):
     request: RedboxQuery
     documents: Annotated[DocumentState, document_reducer] = DocumentState()
     route_name: str | None = None
-    tool_calls: Annotated[list[ToolCall] | None, tool_calls_reducer] = None
     metadata: Annotated[RequestMetadata | None, metadata_reducer] = None
     citations: list[Citation] | None = None
     steps_left: Annotated[int | None, RemainingStepsManager] = None

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -6,7 +6,7 @@ from typing import Annotated, Literal, NotRequired, Required, TypedDict, get_arg
 from uuid import UUID, uuid4
 
 from langchain_core.documents import Document
-from langchain_core.messages import AnyMessage, ToolCall
+from langchain_core.messages import AnyMessage
 from langgraph.graph.message import add_messages
 from langgraph.managed.is_last_step import RemainingStepsManager
 from pydantic import BaseModel, Field
@@ -228,39 +228,6 @@ def metadata_reducer(
         selected_files_total_tokens=update.selected_files_total_tokens or current.selected_files_total_tokens,
         number_of_selected_files=update.number_of_selected_files or current.number_of_selected_files,
     )
-
-
-def tool_calls_reducer(current: list[ToolCall], update: ToolCall | list[ToolCall] | None) -> list[ToolCall]:
-    """Handles updates to the tool state.
-
-    * If a new key is added, adds it to the state.
-    * If an existing key is None'd, removes it
-    * If update is None, clears all tool calls
-    """
-    if not update:
-        return []
-
-    reduced = current.copy()
-
-    try:
-        _reduced = {v["id"]: ToolCall(**v) for v in reduced}
-    except Exception:
-        raise
-
-    if isinstance(update, dict):
-        _update = {update["id"]: ToolCall(**update)}
-    elif isinstance(update, list):
-        _update = {v["id"]: ToolCall(**v) for v in update if v}
-    else:
-        raise ValueError
-
-    for key, value in _update.items():
-        if value is None:
-            _reduced.pop(key, None)
-        else:
-            _reduced[key] = value
-
-    return list(_reduced.values())
 
 
 class RedboxState(BaseModel):

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -129,6 +129,7 @@ RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n====
 
 AGENTIC_RETRIEVAL_QUESTION_PROMPT = (
     "The following context and previous actions are provided to assist you. \n\n"
+    "Previous tool calls: \n\n <ToolCalls> \n\n  {tool_calls} </ToolCalls> \n\n "
     "Document snippets: \n\n <Documents> \n\n {formatted_documents} </Documents> \n\n "
     "User question: \n\n {question}"
 )

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -135,6 +135,7 @@ AGENTIC_RETRIEVAL_QUESTION_PROMPT = (
 
 AGENTIC_GIVE_UP_QUESTION_PROMPT = (
     "The following context and previous actions are provided to assist you. \n\n"
+    "Previous tool calls: \n\n <ToolCalls> \n\n  {tool_calls} </ToolCalls> \n\n "
     "Document snippets: \n\n <Documents> \n\n {formatted_documents} </Documents> \n\n "
     "Previous agent's response: \n\n <AIResponse> \n\n {messages} \n\n </AIResponse> \n\n "
     "User question: \n\n {question}"

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -129,14 +129,12 @@ RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n====
 
 AGENTIC_RETRIEVAL_QUESTION_PROMPT = (
     "The following context and previous actions are provided to assist you. \n\n"
-    "Previous tool calls: \n\n <ToolCalls> \n\n  {tool_calls} </ToolCalls> \n\n "
     "Document snippets: \n\n <Documents> \n\n {formatted_documents} </Documents> \n\n "
     "User question: \n\n {question}"
 )
 
 AGENTIC_GIVE_UP_QUESTION_PROMPT = (
     "The following context and previous actions are provided to assist you. \n\n"
-    "Previous tool calls: \n\n <ToolCalls> \n\n  {tool_calls} </ToolCalls> \n\n "
     "Document snippets: \n\n <Documents> \n\n {formatted_documents} </Documents> \n\n "
     "Previous agent's response: \n\n <AIResponse> \n\n {messages} \n\n </AIResponse> \n\n "
     "User question: \n\n {question}"

--- a/redbox-core/redbox/transform.py
+++ b/redbox-core/redbox/transform.py
@@ -4,10 +4,10 @@ from uuid import NAMESPACE_DNS, UUID, uuid5
 import tiktoken
 from langchain_core.callbacks.manager import dispatch_custom_event
 from langchain_core.documents import Document
-from langchain_core.messages import AIMessage, AnyMessage
+from langchain_core.messages import AIMessage, AnyMessage, ToolCall
 from langchain_core.runnables import RunnableLambda
 
-from redbox.models.chain import DocumentGroup, DocumentState, LLMCallMetadata, RedboxState, RequestMetadata, ToolState
+from redbox.models.chain import DocumentGroup, DocumentState, LLMCallMetadata, RedboxState, RequestMetadata
 from redbox.models.graph import RedboxEventType
 
 
@@ -271,9 +271,9 @@ def sort_documents(documents: list[Document]) -> list[Document]:
     return list(itertools.chain.from_iterable(all_sorted_blocks_by_max_score))
 
 
-def tool_calls_to_toolstate(message: AnyMessage, called: bool | None = False) -> ToolState:
+def tool_calls_to_toolstate(message: AnyMessage, called: bool | None = False) -> list[ToolCall]:
     """Takes a list of tool calls and shapes them into a valid ToolState.
 
     Sets all tool calls to a called state. Assumes this state is False.
     """
-    return ToolState({t["id"]: t for t in message.tool_calls})
+    return message.tool_calls

--- a/redbox-core/redbox/transform.py
+++ b/redbox-core/redbox/transform.py
@@ -124,7 +124,7 @@ def get_document_token_count(state: RedboxState) -> int:
     return sum(d.metadata["token_count"] for d in flatten_document_state(state.documents))
 
 
-def to_request_metadata(obj: dict):
+def to_request_metadata(obj: dict) -> RequestMetadata:
     """Takes a dictionary with keys 'prompt', 'response' and 'model' and creates metadata.
 
     Will also emit events for metadata updates.

--- a/redbox-core/redbox/transform.py
+++ b/redbox-core/redbox/transform.py
@@ -170,7 +170,6 @@ def get_all_metadata(obj: dict):
 
     out = {
         "messages": [AIMessage(content=text, tool_calls=text_and_tools["raw_response"].tool_calls)],
-        "tool_calls": text_and_tools["raw_response"].tool_calls,
         "metadata": to_request_metadata(obj),
         "citations": citations,
     }

--- a/redbox-core/redbox/transform.py
+++ b/redbox-core/redbox/transform.py
@@ -4,7 +4,7 @@ from uuid import NAMESPACE_DNS, UUID, uuid5
 import tiktoken
 from langchain_core.callbacks.manager import dispatch_custom_event
 from langchain_core.documents import Document
-from langchain_core.messages import AIMessage, AnyMessage, ToolCall
+from langchain_core.messages import AIMessage, AnyMessage
 from langchain_core.runnables import RunnableLambda
 
 from redbox.models.chain import DocumentGroup, DocumentState, LLMCallMetadata, RedboxState, RequestMetadata, ToolState
@@ -276,4 +276,4 @@ def tool_calls_to_toolstate(message: AnyMessage, called: bool | None = False) ->
 
     Sets all tool calls to a called state. Assumes this state is False.
     """
-    return ToolState({t["id"]: {"tool": ToolCall(**t), "called": called} for t in message.tool_calls})
+    return ToolState({t["id"]: t for t in message.tool_calls})

--- a/redbox-core/redbox/transform.py
+++ b/redbox-core/redbox/transform.py
@@ -4,7 +4,7 @@ from uuid import NAMESPACE_DNS, UUID, uuid5
 import tiktoken
 from langchain_core.callbacks.manager import dispatch_custom_event
 from langchain_core.documents import Document
-from langchain_core.messages import AIMessage, AnyMessage, ToolCall
+from langchain_core.messages import AIMessage
 from langchain_core.runnables import RunnableLambda
 
 from redbox.models.chain import DocumentGroup, DocumentState, LLMCallMetadata, RedboxState, RequestMetadata
@@ -169,8 +169,8 @@ def get_all_metadata(obj: dict):
         citations = []
 
     out = {
-        "messages": [AIMessage(content=text)],
-        "tool_calls": text_and_tools["tool_calls"],
+        "messages": [AIMessage(content=text, tool_calls=text_and_tools["raw_response"].tool_calls)],
+        "tool_calls": text_and_tools["raw_response"].tool_calls,
         "metadata": to_request_metadata(obj),
         "citations": citations,
     }
@@ -269,11 +269,3 @@ def sort_documents(documents: list[Document]) -> list[Document]:
 
     # Step 4: Flatten the list of blocks back into a single list
     return list(itertools.chain.from_iterable(all_sorted_blocks_by_max_score))
-
-
-def tool_calls_to_toolstate(message: AnyMessage, called: bool | None = False) -> list[ToolCall]:
-    """Takes a list of tool calls and shapes them into a valid ToolState.
-
-    Sets all tool calls to a called state. Assumes this state is False.
-    """
-    return message.tool_calls

--- a/redbox-core/tests/graph/nodes/test_sends.py
+++ b/redbox-core/tests/graph/nodes/test_sends.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 
 from langchain_core.documents import Document
-from langchain_core.messages import ToolCall
+from langchain_core.messages import ToolCall, AIMessage
 from langgraph.constants import Send
 
 from redbox.graph.nodes.sends import build_document_chunk_send, build_document_group_send, build_tool_send
@@ -83,8 +83,7 @@ def test_build_tool_send():
     actual = tool_send(
         RedboxState(
             request=request,
-            tool_calls=tool_call_1 + tool_call_2,
-            text=None,
+            messages=[AIMessage(content="", tool_calls=tool_call_1 + tool_call_2)],
             route_name=None,
         ),
     )
@@ -93,8 +92,7 @@ def test_build_tool_send():
             node=target,
             arg=RedboxState(
                 request=request,
-                tool_calls=tool_call_1,
-                text=None,
+                messages=[AIMessage(content="", tool_calls=tool_call_1)],
                 route_name=None,
             ),
         ),
@@ -102,8 +100,7 @@ def test_build_tool_send():
             node=target,
             arg=RedboxState(
                 request=request,
-                tool_calls=tool_call_2,
-                text=None,
+                messages=[AIMessage(content="", tool_calls=tool_call_2)],
                 route_name=None,
             ),
         ),

--- a/redbox-core/tests/graph/nodes/test_sends.py
+++ b/redbox-core/tests/graph/nodes/test_sends.py
@@ -77,13 +77,10 @@ def test_build_tool_send():
     request = RedboxQuery(question="what colour is the sky?", user_uuid=uuid4(), chat_history=[])
 
     tool_call_1 = {
-        "foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False},
+        "foo": ToolCall(name="foo", args={"a": 1, "b": 2}, id="123"),
     }
     tool_call_2 = {
-        "bar": {
-            "tool": ToolCall({"name": "bar", "args": {"x": 10, "y": 20}, "id": "456"}),
-            "called": False,
-        },
+        "bar": ToolCall(name="bar", args={"x": 10, "y": 20}, id="456"),
     }
 
     tool_send = build_tool_send("my-target")

--- a/redbox-core/tests/graph/nodes/test_sends.py
+++ b/redbox-core/tests/graph/nodes/test_sends.py
@@ -5,7 +5,7 @@ from langchain_core.messages import ToolCall
 from langgraph.constants import Send
 
 from redbox.graph.nodes.sends import build_document_chunk_send, build_document_group_send, build_tool_send
-from redbox.models.chain import DocumentState, RedboxQuery, RedboxState, ToolState
+from redbox.models.chain import DocumentState, RedboxQuery, RedboxState
 
 
 def test_build_document_group_send():
@@ -76,18 +76,14 @@ def test_build_tool_send():
     target = "my-target"
     request = RedboxQuery(question="what colour is the sky?", user_uuid=uuid4(), chat_history=[])
 
-    tool_call_1 = {
-        "foo": ToolCall(name="foo", args={"a": 1, "b": 2}, id="123"),
-    }
-    tool_call_2 = {
-        "bar": ToolCall(name="bar", args={"x": 10, "y": 20}, id="456"),
-    }
+    tool_call_1 = [ToolCall(name="foo", args={"a": 1, "b": 2}, id="123")]
+    tool_call_2 = [ToolCall(name="bar", args={"x": 10, "y": 20}, id="456")]
 
     tool_send = build_tool_send("my-target")
     actual = tool_send(
         RedboxState(
             request=request,
-            tool_calls=ToolState(tool_call_1 | tool_call_2),
+            tool_calls=tool_call_1 + tool_call_2,
             text=None,
             route_name=None,
         ),
@@ -97,7 +93,7 @@ def test_build_tool_send():
             node=target,
             arg=RedboxState(
                 request=request,
-                tool_calls=ToolState(tool_call_1),
+                tool_calls=tool_call_1,
                 text=None,
                 route_name=None,
             ),
@@ -106,7 +102,7 @@ def test_build_tool_send():
             node=target,
             arg=RedboxState(
                 request=request,
-                tool_calls=ToolState(tool_call_2),
+                tool_calls=tool_call_2,
                 text=None,
                 route_name=None,
             ),

--- a/redbox-core/tests/graph/test_patterns.py
+++ b/redbox-core/tests/graph/test_patterns.py
@@ -30,7 +30,7 @@ from redbox.test.data import (
     mock_all_chunks_retriever,
     mock_parameterised_retriever,
 )
-from redbox.transform import flatten_document_state, structure_documents_by_file_name, tool_calls_to_toolstate
+from redbox.transform import flatten_document_state, structure_documents_by_file_name
 
 LANGGRAPH_DEBUG = True
 
@@ -101,12 +101,12 @@ def test_build_llm_chain(test_case: RedboxChatTestCase):
     final_state = llm_chain.invoke(state)
 
     test_case_content = test_case.test_data.llm_responses[-1].content
-    test_case_tool_calls = tool_calls_to_toolstate(test_case.test_data.llm_responses[-1])
+    test_case_tool_calls = test_case.test_data.llm_responses[-1].tool_calls
 
     assert (
         final_state["messages"][-1].content == test_case_content
     ), f"Expected LLM response: '{test_case_content}'. Received '{final_state["messages"][-1].content}'"
-    assert final_state["tool_calls"] == test_case_tool_calls
+    assert final_state["messages"][-1].tool_calls == test_case_tool_calls
     assert sum(final_state["metadata"].input_tokens.values())
     assert sum(final_state["metadata"].output_tokens.values())
 

--- a/redbox-core/tests/graph/test_state.py
+++ b/redbox-core/tests/graph/test_state.py
@@ -342,6 +342,8 @@ TEST_QUERY = RedboxQuery(
                 route_name="my_route",
                 tool_calls=[
                     {"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"},
+                    None,
+                    {"args": {"a": 1, "b": 2}, "id": "123", "name": "foo"},
                 ],
                 metadata=RequestMetadata(
                     llm_calls=[

--- a/redbox-core/tests/graph/test_state.py
+++ b/redbox-core/tests/graph/test_state.py
@@ -224,10 +224,6 @@ TEST_QUERY = RedboxQuery(
                 ),
                 text="Some old text",
                 route_name="my_route",
-                tool_calls=[
-                    {"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"},
-                    {"name": "bar", "args": {"a": 1, "b": 2}, "id": "123"},
-                ],
                 metadata=RequestMetadata(
                     llm_calls=[
                         {
@@ -261,11 +257,6 @@ TEST_QUERY = RedboxQuery(
                     }
                 ),
                 text="Some new text",
-                tool_calls=[
-                    {"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"},
-                    None,
-                    {"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"},
-                ],
                 metadata=RequestMetadata(
                     llm_calls=[
                         {
@@ -292,11 +283,6 @@ TEST_QUERY = RedboxQuery(
                 ),
                 text="Some new text",
                 route_name="my_route",
-                tool_calls=[
-                    {"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"},
-                    None,
-                    {"args": {"a": 1, "b": 2}, "id": "123", "name": "foo"},
-                ],
                 metadata=RequestMetadata(
                     llm_calls=[
                         {

--- a/redbox-core/tests/graph/test_state.py
+++ b/redbox-core/tests/graph/test_state.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 
 import pytest
 from langchain_core.documents import Document
-from langchain_core.messages import ToolCall
 
 from redbox.models.chain import (
     AISettings,
@@ -14,7 +13,6 @@ from redbox.models.chain import (
     document_reducer,
     merge_redbox_state_updates,
     metadata_reducer,
-    tool_calls_reducer,
 )
 
 GROUP_IDS = [uuid4() for _ in range(4)]
@@ -195,52 +193,6 @@ multiple_models_multiple_calls_1a = multiple_models_multiple_calls_1 + [
 )
 def test_metadata_reducer(a: RequestMetadata, b: RequestMetadata, expected: RequestMetadata):
     result = metadata_reducer(a, b)
-    assert result == expected, f"Expected: {expected}. Result: {result}"
-
-
-@pytest.mark.parametrize(
-    ("a", "b", "expected"),
-    [
-        (
-            [
-                ToolCall(name="foo", args={"a": 1, "b": 2}, id="123"),
-                ToolCall(name="bar", args={"x": 10, "y": 20}, id="456"),
-            ],
-            [ToolCall(name="baz", args={"param": "value"}, id="789", type="tool_call")],
-            [
-                ToolCall(name="foo", args={"a": 1, "b": 2}, id="123"),
-                ToolCall(name="bar", args={"x": 10, "y": 20}, id="456"),
-                ToolCall(name="baz", args={"param": "value"}, id="789", type="tool_call"),
-            ],
-        ),
-        (
-            [
-                ToolCall(name="foo", args={"a": 1, "b": 2}, id="123"),
-                ToolCall(name="bar", args={"x": 10, "y": 20}, id="456"),
-            ],
-            [ToolCall(name="baz", args={"param": "value"}, id="456", type="tool_call")],
-            [
-                ToolCall(name="foo", args={"a": 1, "b": 2}, id="123"),
-                ToolCall(name="baz", args={"param": "value"}, id="456", type="tool_call"),
-            ],
-        ),
-        (
-            [
-                ToolCall(name="foo", args={"a": 1, "b": 2}, id="123"),
-            ],
-            [],
-            [],
-        ),
-    ],
-)
-def test_tool_calls_reducer(a: list[ToolCall], b: list[ToolCall], expected: list[ToolCall]):
-    """Checks the key properties of the ToolState reducer.
-
-    * If a new key is added, adds it to the state.
-    * If an existing key is None'd, removes it
-    * If update is None, clears all tool calls
-    """
-    result = tool_calls_reducer(a, b)
     assert result == expected, f"Expected: {expected}. Result: {result}"
 
 

--- a/redbox-core/tests/graph/test_state.py
+++ b/redbox-core/tests/graph/test_state.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 
 import pytest
 from langchain_core.documents import Document
-from langchain_core.messages import ToolCall
 
 from redbox.models.chain import (
     AISettings,
@@ -11,11 +10,9 @@ from redbox.models.chain import (
     LLMCallMetadata,
     RedboxQuery,
     RequestMetadata,
-    ToolState,
     document_reducer,
     merge_redbox_state_updates,
     metadata_reducer,
-    tool_calls_reducer,
 )
 
 GROUP_IDS = [uuid4() for _ in range(4)]
@@ -199,85 +196,73 @@ def test_metadata_reducer(a: RequestMetadata, b: RequestMetadata, expected: Requ
     assert result == expected, f"Expected: {expected}. Result: {result}"
 
 
-@pytest.mark.parametrize(
-    ("a", "b", "expected"),
-    [
-        (
-            ToolState(
-                {
-                    "foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False},
-                    "bar": {
-                        "tool": ToolCall({"name": "bar", "args": {"x": 10, "y": 20}, "id": "456"}),
-                        "called": False,
-                    },
-                }
-            ),
-            ToolState(
-                {
-                    "baz": {
-                        "tool": ToolCall({"name": "baz", "args": {"param": "value"}, "id": "789", "type": "tool_call"}),
-                        "called": False,
-                    }
-                }
-            ),
-            ToolState(
-                {
-                    "foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False},
-                    "bar": {
-                        "tool": ToolCall({"name": "bar", "args": {"x": 10, "y": 20}, "id": "456"}),
-                        "called": False,
-                    },
-                    "baz": {
-                        "tool": ToolCall({"name": "baz", "args": {"param": "value"}, "id": "789", "type": "tool_call"}),
-                        "called": False,
-                    },
-                }
-            ),
-        ),
-        (
-            ToolState(
-                {
-                    "foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False},
-                    "bar": {
-                        "tool": ToolCall({"name": "bar", "args": {"x": 10, "y": 20}, "id": "456"}),
-                        "called": False,
-                    },
-                }
-            ),
-            ToolState({"bar": None}),
-            ToolState(
-                {"foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False}}
-            ),
-        ),
-        (
-            ToolState(
-                {"foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False}}
-            ),
-            None,
-            ToolState(),
-        ),
-        (
-            ToolState(
-                {"foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False}}
-            ),
-            ToolState(
-                {"foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": True}}
-            ),
-            ToolState(
-                {"foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": True}}
-            ),
-        ),
-    ],
-)
-def test_tool_calls_reducer(a: ToolState, b: ToolState, expected: ToolState):
-    """Checks the key properties of the ToolState reducer.
-
-    * If a new key is added, adds it to the state.
-    * If an existing key is None'd, removes it
-    * If update is None, clears all tool calls
-    """
-    result = tool_calls_reducer(a, b)
-    assert result == expected, f"Expected: {expected}. Result: {result}"
+# @pytest.mark.parametrize(
+#     ("a", "b", "expected"),
+#     [
+#         (
+#             ToolState(
+#                 {
+#                     "foo": [ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"})],
+#                     "bar": [ToolCall({"name": "bar", "args": {"x": 10, "y": 20}, "id": "456"})],
+#                 }
+#             ),
+#             ToolState(
+#                 {
+#                     "baz": [ToolCall({"name": "baz", "args": {"param": "value"}, "id": "789", "type": "tool_call"})]
+#                 }
+#             ),
+#             ToolState(
+#                 {
+#                     "foo": [ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"})],
+#                     "bar": [ToolCall({"name": "bar", "args": {"x": 10, "y": 20}, "id": "456"})],
+#                     "baz": [ToolCall({"name": "baz", "args": {"param": "value"}, "id": "789", "type": "tool_call"})]
+#                 }
+#             ),
+#         ),
+#         (
+#             ToolState(
+#                 {
+#                     "foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False},
+#                     "bar": {
+#                         "tool": ToolCall({"name": "bar", "args": {"x": 10, "y": 20}, "id": "456"}),
+#                         "called": False,
+#                     },
+#                 }
+#             ),
+#             ToolState({"bar": None}),
+#             ToolState(
+#                 {"foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False}}
+#             ),
+#         ),
+#         (
+#             ToolState(
+#                 {"foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False}}
+#             ),
+#             None,
+#             ToolState(),
+#         ),
+#         (
+#             ToolState(
+#                 {"foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": False}}
+#             ),
+#             ToolState(
+#                 {"foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": True}}
+#             ),
+#             ToolState(
+#                 {"foo": {"tool": ToolCall({"name": "foo", "args": {"a": 1, "b": 2}, "id": "123"}), "called": True}}
+#             ),
+#         ),
+#     ],
+# )
+# def test_tool_calls_reducer(a: list[ToolCall], b: list[ToolCall], expected: list[ToolCall]):
+#     """Checks the key properties of the ToolState reducer.
+#
+#     * If a new key is added, adds it to the state.
+#     * If an existing key is None'd, removes it
+#     * If update is None, clears all tool calls
+#     """
+#     result = tool_calls_reducer(a, b)
+#     assert result == expected, f"Expected: {expected}. Result: {result}"
 
 
 TEST_QUERY = RedboxQuery(

--- a/redbox-core/tests/test_tools.py
+++ b/redbox-core/tests/test_tools.py
@@ -1,4 +1,3 @@
-from typing import Annotated, Any
 from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
@@ -6,15 +5,11 @@ import pytest
 from elasticsearch import Elasticsearch
 from langchain_core.embeddings.fake import FakeEmbeddings
 from langchain_core.messages import HumanMessage
-from langchain_core.tools import tool
-from langgraph.prebuilt import InjectedState
 
 from redbox.graph.nodes.tools import (
     build_govuk_search_tool,
     build_search_documents_tool,
     build_search_wikipedia_tool,
-    has_injected_state,
-    is_valid_tool,
 )
 from redbox.models.settings import Settings
 from redbox.models.chain import AISettings, RedboxQuery, RedboxState
@@ -22,36 +17,6 @@ from redbox.models.file import ChunkCreatorType, ChunkMetadata, ChunkResolution
 from redbox.test.data import RedboxChatTestCase
 from redbox.transform import flatten_document_state
 from tests.retriever.test_retriever import TEST_CHAIN_PARAMETERS
-
-
-def test_is_valid_tool():
-    @tool
-    def tool_with_type_hinting() -> dict[str, Any]:
-        """Tool that returns a dictionary update."""
-        return {"key": "value"}
-
-    @tool
-    def tool_without_type_hinting():
-        """Tool that returns a dictionary update."""
-        return {"key": "value"}
-
-    assert is_valid_tool(tool_with_type_hinting)
-    assert not is_valid_tool(tool_without_type_hinting)
-
-
-def test_has_injected_state():
-    @tool
-    def tool_with_injected_state(query: str, state: Annotated[dict, InjectedState]) -> dict[str, Any]:
-        """Tool that returns a dictionary update."""
-        return {"key": "value"}
-
-    @tool
-    def tool_without_injected_state(query: str) -> dict[str, Any]:
-        """Tool that returns a dictionary update."""
-        return {"key": "value"}
-
-    assert has_injected_state(tool_with_injected_state)
-    assert not has_injected_state(tool_without_injected_state)
 
 
 @pytest.mark.parametrize("chain_params", TEST_CHAIN_PARAMETERS)


### PR DESCRIPTION
## Context

As an Engineer I want to reuse existing tools where possible such as https://langchain-ai.github.io/langgraph/reference/prebuilt/#toolnode so that we have less code to maintain and it is clearer what we have added to langchain vs what we have just rewritten.

## Changes proposed in this pull request

1. `build_tool_pattern` has been replaced with `ToolNode`
2. `tool_calls` and associated reducer has been removed from the `RedboxState`, the `tool_calls` data is now accessable from `last_message.tool_calls`
3. intermediate objects like `ToolStateEntry` have been removed

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
