### PR TITLE
Bugfix/gov search irrelevant

### DIFF
--- a/django_app/poetry.lock
+++ b/django_app/poetry.lock
@@ -2442,6 +2442,17 @@ files = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.4.2"
+description = "Lightweight pipelining with Python functions"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "joblib-1.4.2-py3-none-any.whl", hash = "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6"},
+    {file = "joblib-1.4.2.tar.gz", hash = "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e"},
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 description = "Apply JSON-Patches (RFC 6902)"
@@ -4416,6 +4427,56 @@ botocore = ">=1.33.2,<2.0a.0"
 crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
+name = "scikit-learn"
+version = "1.5.2"
+description = "A set of python modules for machine learning and data mining"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "scikit_learn-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:299406827fb9a4f862626d0fe6c122f5f87f8910b86fe5daa4c32dcd742139b6"},
+    {file = "scikit_learn-1.5.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:2d4cad1119c77930b235579ad0dc25e65c917e756fe80cab96aa3b9428bd3fb0"},
+    {file = "scikit_learn-1.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c412ccc2ad9bf3755915e3908e677b367ebc8d010acbb3f182814524f2e5540"},
+    {file = "scikit_learn-1.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a686885a4b3818d9e62904d91b57fa757fc2bed3e465c8b177be652f4dd37c8"},
+    {file = "scikit_learn-1.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:c15b1ca23d7c5f33cc2cb0a0d6aaacf893792271cddff0edbd6a40e8319bc113"},
+    {file = "scikit_learn-1.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:03b6158efa3faaf1feea3faa884c840ebd61b6484167c711548fce208ea09445"},
+    {file = "scikit_learn-1.5.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:1ff45e26928d3b4eb767a8f14a9a6efbf1cbff7c05d1fb0f95f211a89fd4f5de"},
+    {file = "scikit_learn-1.5.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f763897fe92d0e903aa4847b0aec0e68cadfff77e8a0687cabd946c89d17e675"},
+    {file = "scikit_learn-1.5.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8b0ccd4a902836493e026c03256e8b206656f91fbcc4fde28c57a5b752561f1"},
+    {file = "scikit_learn-1.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:6c16d84a0d45e4894832b3c4d0bf73050939e21b99b01b6fd59cbb0cf39163b6"},
+    {file = "scikit_learn-1.5.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f932a02c3f4956dfb981391ab24bda1dbd90fe3d628e4b42caef3e041c67707a"},
+    {file = "scikit_learn-1.5.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:3b923d119d65b7bd555c73be5423bf06c0105678ce7e1f558cb4b40b0a5502b1"},
+    {file = "scikit_learn-1.5.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f60021ec1574e56632be2a36b946f8143bf4e5e6af4a06d85281adc22938e0dd"},
+    {file = "scikit_learn-1.5.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:394397841449853c2290a32050382edaec3da89e35b3e03d6cc966aebc6a8ae6"},
+    {file = "scikit_learn-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:57cc1786cfd6bd118220a92ede80270132aa353647684efa385a74244a41e3b1"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9a702e2de732bbb20d3bad29ebd77fc05a6b427dc49964300340e4c9328b3f5"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:b0768ad641981f5d3a198430a1d31c3e044ed2e8a6f22166b4d546a5116d7908"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:178ddd0a5cb0044464fc1bfc4cca5b1833bfc7bb022d70b05db8530da4bb3dd3"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7284ade780084d94505632241bf78c44ab3b6f1e8ccab3d2af58e0e950f9c12"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:b7b0f9a0b1040830d38c39b91b3a44e1b643f4b36e36567b80b7c6bd2202a27f"},
+    {file = "scikit_learn-1.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:757c7d514ddb00ae249832fe87100d9c73c6ea91423802872d9e74970a0e40b9"},
+    {file = "scikit_learn-1.5.2-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:52788f48b5d8bca5c0736c175fa6bdaab2ef00a8f536cda698db61bd89c551c1"},
+    {file = "scikit_learn-1.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:643964678f4b5fbdc95cbf8aec638acc7aa70f5f79ee2cdad1eec3df4ba6ead8"},
+    {file = "scikit_learn-1.5.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca64b3089a6d9b9363cd3546f8978229dcbb737aceb2c12144ee3f70f95684b7"},
+    {file = "scikit_learn-1.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:3bed4909ba187aca80580fe2ef370d9180dcf18e621a27c4cf2ef10d279a7efe"},
+    {file = "scikit_learn-1.5.2.tar.gz", hash = "sha256:b4237ed7b3fdd0a4882792e68ef2545d5baa50aca3bb45aa7df468138ad8f94d"},
+]
+
+[package.dependencies]
+joblib = ">=1.2.0"
+numpy = ">=1.19.5"
+scipy = ">=1.6.0"
+threadpoolctl = ">=3.1.0"
+
+[package.extras]
+benchmark = ["matplotlib (>=3.3.4)", "memory_profiler (>=0.57.0)", "pandas (>=1.1.5)"]
+build = ["cython (>=3.0.10)", "meson-python (>=0.16.0)", "numpy (>=1.19.5)", "scipy (>=1.6.0)"]
+docs = ["Pillow (>=7.1.2)", "matplotlib (>=3.3.4)", "memory_profiler (>=0.57.0)", "numpydoc (>=1.2.0)", "pandas (>=1.1.5)", "plotly (>=5.14.0)", "polars (>=0.20.30)", "pooch (>=1.6.0)", "pydata-sphinx-theme (>=0.15.3)", "scikit-image (>=0.17.2)", "seaborn (>=0.9.0)", "sphinx (>=7.3.7)", "sphinx-copybutton (>=0.5.2)", "sphinx-design (>=0.5.0)", "sphinx-design (>=0.6.0)", "sphinx-gallery (>=0.16.0)", "sphinx-prompt (>=1.4.0)", "sphinx-remove-toctrees (>=1.0.0.post1)", "sphinxcontrib-sass (>=0.3.4)", "sphinxext-opengraph (>=0.9.1)"]
+examples = ["matplotlib (>=3.3.4)", "pandas (>=1.1.5)", "plotly (>=5.14.0)", "pooch (>=1.6.0)", "scikit-image (>=0.17.2)", "seaborn (>=0.9.0)"]
+install = ["joblib (>=1.2.0)", "numpy (>=1.19.5)", "scipy (>=1.6.0)", "threadpoolctl (>=3.1.0)"]
+maintenance = ["conda-lock (==2.5.6)"]
+tests = ["black (>=24.3.0)", "matplotlib (>=3.3.4)", "mypy (>=1.9)", "numpydoc (>=1.2.0)", "pandas (>=1.1.5)", "polars (>=0.20.30)", "pooch (>=1.6.0)", "pyamg (>=4.0.0)", "pyarrow (>=12.0.0)", "pytest (>=7.1.2)", "pytest-cov (>=2.9.0)", "ruff (>=0.2.1)", "scikit-image (>=0.17.2)"]
+
+[[package]]
 name = "scipy"
 version = "1.14.1"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -4861,6 +4922,17 @@ files = [
 [package.extras]
 doc = ["reno", "sphinx"]
 test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.5.0"
+description = "threadpoolctl"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "threadpoolctl-3.5.0-py3-none-any.whl", hash = "sha256:56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467"},
+    {file = "threadpoolctl-3.5.0.tar.gz", hash = "sha256:082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107"},
+]
 
 [[package]]
 name = "tiktoken"
@@ -5516,4 +5588,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<3.13"
-content-hash = "8cffd3cfd05cbbad32941b45a3a6e4c375709c78915802c9602d144364790bee"
+content-hash = "8d4609dca19fbed4cafdbefd3bd83768b5156d9dc765a807a33ce21be31c08b3"

--- a/django_app/pyproject.toml
+++ b/django_app/pyproject.toml
@@ -44,6 +44,7 @@ django-adminplus = "^0.6"
 pandas = "^2.2.2"
 django-waffle = "^4.1.0"
 opensearch-py = "^2.7.1"
+scikit-learn = "^1.5.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/redbox-core/poetry.lock
+++ b/redbox-core/poetry.lock
@@ -1845,6 +1845,17 @@ files = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.4.2"
+description = "Lightweight pipelining with Python functions"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "joblib-1.4.2-py3-none-any.whl", hash = "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6"},
+    {file = "joblib-1.4.2.tar.gz", hash = "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e"},
+]
+
+[[package]]
 name = "jsonlines"
 version = "4.0.0"
 description = "Library with helpers for the jsonlines file format"
@@ -3131,6 +3142,19 @@ files = [
     {file = "pyarrow-17.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:392bc9feabc647338e6c89267635e111d71edad5fcffba204425a7c8d13610d7"},
     {file = "pyarrow-17.0.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:af5ff82a04b2171415f1410cff7ebb79861afc5dae50be73ce06d6e870615204"},
     {file = "pyarrow-17.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:edca18eaca89cd6382dfbcff3dd2d87633433043650c07375d095cd3517561d8"},
+    {file = "pyarrow-17.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c7916bff914ac5d4a8fe25b7a25e432ff921e72f6f2b7547d1e325c1ad9d155"},
+    {file = "pyarrow-17.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f553ca691b9e94b202ff741bdd40f6ccb70cdd5fbf65c187af132f1317de6145"},
+    {file = "pyarrow-17.0.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:0cdb0e627c86c373205a2f94a510ac4376fdc523f8bb36beab2e7f204416163c"},
+    {file = "pyarrow-17.0.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:d7d192305d9d8bc9082d10f361fc70a73590a4c65cf31c3e6926cd72b76bc35c"},
+    {file = "pyarrow-17.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:02dae06ce212d8b3244dd3e7d12d9c4d3046945a5933d28026598e9dbbda1fca"},
+    {file = "pyarrow-17.0.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:13d7a460b412f31e4c0efa1148e1d29bdf18ad1411eb6757d38f8fbdcc8645fb"},
+    {file = "pyarrow-17.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9b564a51fbccfab5a04a80453e5ac6c9954a9c5ef2890d1bcf63741909c3f8df"},
+    {file = "pyarrow-17.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32503827abbc5aadedfa235f5ece8c4f8f8b0a3cf01066bc8d29de7539532687"},
+    {file = "pyarrow-17.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a155acc7f154b9ffcc85497509bcd0d43efb80d6f733b0dc3bb14e281f131c8b"},
+    {file = "pyarrow-17.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:dec8d129254d0188a49f8a1fc99e0560dc1b85f60af729f47de4046015f9b0a5"},
+    {file = "pyarrow-17.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:a48ddf5c3c6a6c505904545c25a4ae13646ae1f8ba703c4df4a1bfe4f4006bda"},
+    {file = "pyarrow-17.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:42bf93249a083aca230ba7e2786c5f673507fa97bbd9725a1e2754715151a204"},
+    {file = "pyarrow-17.0.0.tar.gz", hash = "sha256:4beca9521ed2c0921c1023e68d097d0299b62c362639ea315572a58f3f50fd28"},
 ]
 
 [package.dependencies]
@@ -3804,6 +3828,56 @@ botocore = ">=1.33.2,<2.0a.0"
 crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
+name = "scikit-learn"
+version = "1.5.2"
+description = "A set of python modules for machine learning and data mining"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "scikit_learn-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:299406827fb9a4f862626d0fe6c122f5f87f8910b86fe5daa4c32dcd742139b6"},
+    {file = "scikit_learn-1.5.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:2d4cad1119c77930b235579ad0dc25e65c917e756fe80cab96aa3b9428bd3fb0"},
+    {file = "scikit_learn-1.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c412ccc2ad9bf3755915e3908e677b367ebc8d010acbb3f182814524f2e5540"},
+    {file = "scikit_learn-1.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a686885a4b3818d9e62904d91b57fa757fc2bed3e465c8b177be652f4dd37c8"},
+    {file = "scikit_learn-1.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:c15b1ca23d7c5f33cc2cb0a0d6aaacf893792271cddff0edbd6a40e8319bc113"},
+    {file = "scikit_learn-1.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:03b6158efa3faaf1feea3faa884c840ebd61b6484167c711548fce208ea09445"},
+    {file = "scikit_learn-1.5.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:1ff45e26928d3b4eb767a8f14a9a6efbf1cbff7c05d1fb0f95f211a89fd4f5de"},
+    {file = "scikit_learn-1.5.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f763897fe92d0e903aa4847b0aec0e68cadfff77e8a0687cabd946c89d17e675"},
+    {file = "scikit_learn-1.5.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8b0ccd4a902836493e026c03256e8b206656f91fbcc4fde28c57a5b752561f1"},
+    {file = "scikit_learn-1.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:6c16d84a0d45e4894832b3c4d0bf73050939e21b99b01b6fd59cbb0cf39163b6"},
+    {file = "scikit_learn-1.5.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f932a02c3f4956dfb981391ab24bda1dbd90fe3d628e4b42caef3e041c67707a"},
+    {file = "scikit_learn-1.5.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:3b923d119d65b7bd555c73be5423bf06c0105678ce7e1f558cb4b40b0a5502b1"},
+    {file = "scikit_learn-1.5.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f60021ec1574e56632be2a36b946f8143bf4e5e6af4a06d85281adc22938e0dd"},
+    {file = "scikit_learn-1.5.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:394397841449853c2290a32050382edaec3da89e35b3e03d6cc966aebc6a8ae6"},
+    {file = "scikit_learn-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:57cc1786cfd6bd118220a92ede80270132aa353647684efa385a74244a41e3b1"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9a702e2de732bbb20d3bad29ebd77fc05a6b427dc49964300340e4c9328b3f5"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:b0768ad641981f5d3a198430a1d31c3e044ed2e8a6f22166b4d546a5116d7908"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:178ddd0a5cb0044464fc1bfc4cca5b1833bfc7bb022d70b05db8530da4bb3dd3"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7284ade780084d94505632241bf78c44ab3b6f1e8ccab3d2af58e0e950f9c12"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:b7b0f9a0b1040830d38c39b91b3a44e1b643f4b36e36567b80b7c6bd2202a27f"},
+    {file = "scikit_learn-1.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:757c7d514ddb00ae249832fe87100d9c73c6ea91423802872d9e74970a0e40b9"},
+    {file = "scikit_learn-1.5.2-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:52788f48b5d8bca5c0736c175fa6bdaab2ef00a8f536cda698db61bd89c551c1"},
+    {file = "scikit_learn-1.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:643964678f4b5fbdc95cbf8aec638acc7aa70f5f79ee2cdad1eec3df4ba6ead8"},
+    {file = "scikit_learn-1.5.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca64b3089a6d9b9363cd3546f8978229dcbb737aceb2c12144ee3f70f95684b7"},
+    {file = "scikit_learn-1.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:3bed4909ba187aca80580fe2ef370d9180dcf18e621a27c4cf2ef10d279a7efe"},
+    {file = "scikit_learn-1.5.2.tar.gz", hash = "sha256:b4237ed7b3fdd0a4882792e68ef2545d5baa50aca3bb45aa7df468138ad8f94d"},
+]
+
+[package.dependencies]
+joblib = ">=1.2.0"
+numpy = ">=1.19.5"
+scipy = ">=1.6.0"
+threadpoolctl = ">=3.1.0"
+
+[package.extras]
+benchmark = ["matplotlib (>=3.3.4)", "memory_profiler (>=0.57.0)", "pandas (>=1.1.5)"]
+build = ["cython (>=3.0.10)", "meson-python (>=0.16.0)", "numpy (>=1.19.5)", "scipy (>=1.6.0)"]
+docs = ["Pillow (>=7.1.2)", "matplotlib (>=3.3.4)", "memory_profiler (>=0.57.0)", "numpydoc (>=1.2.0)", "pandas (>=1.1.5)", "plotly (>=5.14.0)", "polars (>=0.20.30)", "pooch (>=1.6.0)", "pydata-sphinx-theme (>=0.15.3)", "scikit-image (>=0.17.2)", "seaborn (>=0.9.0)", "sphinx (>=7.3.7)", "sphinx-copybutton (>=0.5.2)", "sphinx-design (>=0.5.0)", "sphinx-design (>=0.6.0)", "sphinx-gallery (>=0.16.0)", "sphinx-prompt (>=1.4.0)", "sphinx-remove-toctrees (>=1.0.0.post1)", "sphinxcontrib-sass (>=0.3.4)", "sphinxext-opengraph (>=0.9.1)"]
+examples = ["matplotlib (>=3.3.4)", "pandas (>=1.1.5)", "plotly (>=5.14.0)", "pooch (>=1.6.0)", "scikit-image (>=0.17.2)", "seaborn (>=0.9.0)"]
+install = ["joblib (>=1.2.0)", "numpy (>=1.19.5)", "scipy (>=1.6.0)", "threadpoolctl (>=3.1.0)"]
+maintenance = ["conda-lock (==2.5.6)"]
+tests = ["black (>=24.3.0)", "matplotlib (>=3.3.4)", "mypy (>=1.9)", "numpydoc (>=1.2.0)", "pandas (>=1.1.5)", "polars (>=0.20.30)", "pooch (>=1.6.0)", "pyamg (>=4.0.0)", "pyarrow (>=12.0.0)", "pytest (>=7.1.2)", "pytest-cov (>=2.9.0)", "ruff (>=0.2.1)", "scikit-image (>=0.17.2)"]
+
+[[package]]
 name = "scipy"
 version = "1.14.1"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -4180,6 +4254,17 @@ files = [
 [package.extras]
 doc = ["reno", "sphinx"]
 test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.5.0"
+description = "threadpoolctl"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "threadpoolctl-3.5.0-py3-none-any.whl", hash = "sha256:56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467"},
+    {file = "threadpoolctl-3.5.0.tar.gz", hash = "sha256:082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107"},
+]
 
 [[package]]
 name = "tiktoken"
@@ -4717,4 +4802,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<3.13"
-content-hash = "292d34acdef753b394760ffa85824cb9d7dfcfd15ea196ac0df498494754d4ee"
+content-hash = "9a38623c319fb9934e7524ad50ccc7ea519fb6aae972dcb5755a8db4327be6d7"

--- a/redbox-core/poetry.lock
+++ b/redbox-core/poetry.lock
@@ -1620,7 +1620,7 @@ http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 trio = ["trio (>=0.22.0,<1.0)"]
 
-[[package]]
+[[package]]pytest
 name = "httpx"
 version = "0.27.2"
 description = "The next generation HTTP client."
@@ -1679,7 +1679,7 @@ typing-extensions = ">=3.7.4.3"
 [package.extras]
 all = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "fastapi", "gradio (>=4.0.0)", "jedi", "libcst (==1.4.0)", "mypy (==1.5.1)", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "ruff (>=0.5.0)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
 cli = ["InquirerPy (==0.3.4)"]
-dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "fastapi", "gradio (>=4.0.0)", "jedi", "libcst (==1.4.0)", "mypy (==1.5.1)", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "ruff (>=0.5.0)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "fastapi", "gradio (>=4.0.0)", "jedi", "libcst (==1.4.0)", "mypy (==1.5.1)", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "-vcr", "pytest-xdist", "ruff (>=0.5.0)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
 fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
 hf-transfer = ["hf-transfer (>=0.1.4)"]
 inference = ["aiohttp"]

--- a/redbox-core/pyproject.toml
+++ b/redbox-core/pyproject.toml
@@ -27,6 +27,7 @@ langgraph = "^0.2.39"
 langchain-aws = "^0.2.3"
 wikipedia = "^1.4.0"
 opensearch-py = "^2.7.1"
+scikit-learn = "^1.5.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/redbox-core/pyproject.toml
+++ b/redbox-core/pyproject.toml
@@ -54,5 +54,6 @@ env_files = [
     ".env"
 ]
 markers = [
-    "ai: marks tests as using a live LLM (deselect with '-m \"not ai\"')"
+    "ai: marks tests as using a live LLM (deselect with '-m \"not ai\"')",
+    "vcr",
 ]

--- a/redbox-core/redbox/graph/nodes/tools.py
+++ b/redbox-core/redbox/graph/nodes/tools.py
@@ -139,7 +139,7 @@ def build_search_documents_tool(
     return _search_documents
 
 
-def build_govuk_search_tool(num_results: int = 1, filter=False) -> Tool:
+def build_govuk_search_tool(num_results: int = 1) -> Tool:
     """Constructs a tool that searches gov.uk and sets state["documents"]."""
 
     tokeniser = tiktoken.encoding_for_model("gpt-4o")
@@ -157,7 +157,7 @@ def build_govuk_search_tool(num_results: int = 1, filter=False) -> Tool:
         return response
 
     @tool
-    def _search_govuk(query: str, state: Annotated[dict, InjectedState], filter=filter) -> dict[str, Any]:
+    def _search_govuk(query: str, state: Annotated[dict, InjectedState]) -> dict[str, Any]:
         """
         Search for documents on gov.uk based on a query string.
         This endpoint is used to search for documents on gov.uk. There are many types of documents on gov.uk.
@@ -186,7 +186,7 @@ def build_govuk_search_tool(num_results: int = 1, filter=False) -> Tool:
             f"{url_base}/api/search.json",
             params={
                 "q": query,
-                "count": 10 if filter else num_results,
+                "count": 10,
                 "fields": required_fields,
             },
             headers={"Accept": "application/json"},
@@ -194,9 +194,7 @@ def build_govuk_search_tool(num_results: int = 1, filter=False) -> Tool:
         response.raise_for_status()
         response = response.json()
 
-        if filter:
-            response = recalculate_similarity(response, query, num_results)
-
+        response = recalculate_similarity(response, query, num_results)
         mapped_documents = []
         for i, doc in enumerate(response["results"]):
             if any(field not in doc for field in required_fields):

--- a/redbox-core/redbox/graph/nodes/tools.py
+++ b/redbox-core/redbox/graph/nodes/tools.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Any, Iterable, get_args, get_origin, get_type_hints
 
+import numpy as np
 import requests
 import tiktoken
 from elasticsearch import Elasticsearch
@@ -9,9 +10,12 @@ from langchain_core.embeddings.embeddings import Embeddings
 from langchain_core.messages import ToolCall
 from langchain_core.tools import StructuredTool, Tool, tool
 from langgraph.prebuilt import InjectedState
+from sklearn.metrics.pairwise import cosine_similarity
 
+from redbox.chains.components import get_embeddings
 from redbox.models.chain import RedboxState
 from redbox.models.file import ChunkCreatorType, ChunkMetadata, ChunkResolution
+from redbox.models.settings import get_settings
 from redbox.retriever.queries import (
     add_document_filter_scores_to_query,
     build_document_query,
@@ -140,6 +144,18 @@ def build_govuk_search_tool(num_results: int = 1) -> Tool:
 
     tokeniser = tiktoken.encoding_for_model("gpt-4o")
 
+    def recalculate_similarity(response, query, num_results):
+        embedding_model = get_embeddings(get_settings())
+        em_query = embedding_model.embed_query(query)
+        for r in response.get("results"):
+            description = r.get("description")
+            em_des = embedding_model.embed_query(description)
+            r["similarity"] = cosine_similarity(np.array(em_query).reshape(1, -1), np.array(em_des).reshape(1, -1))[0][
+                0
+            ]
+        response["results"] = sorted(response.get("results"), key=lambda x: x["similarity"], reverse=True)[:num_results]
+        return response
+
     @tool
     def _search_govuk(query: str, state: Annotated[dict, InjectedState]) -> dict[str, Any]:
         """
@@ -170,7 +186,7 @@ def build_govuk_search_tool(num_results: int = 1) -> Tool:
             f"{url_base}/api/search.json",
             params={
                 "q": query,
-                "count": num_results,
+                "count": 10,
                 "fields": required_fields,
             },
             headers={"Accept": "application/json"},
@@ -178,6 +194,7 @@ def build_govuk_search_tool(num_results: int = 1) -> Tool:
         response.raise_for_status()
         response = response.json()
 
+        response = recalculate_similarity(response, query, num_results)
         mapped_documents = []
         for i, doc in enumerate(response["results"]):
             if any(field not in doc for field in required_fields):

--- a/redbox-core/redbox/graph/nodes/tools.py
+++ b/redbox-core/redbox/graph/nodes/tools.py
@@ -139,7 +139,7 @@ def build_search_documents_tool(
     return _search_documents
 
 
-def build_govuk_search_tool(num_results: int = 1) -> Tool:
+def build_govuk_search_tool(num_results: int = 1, filter=False) -> Tool:
     """Constructs a tool that searches gov.uk and sets state["documents"]."""
 
     tokeniser = tiktoken.encoding_for_model("gpt-4o")
@@ -157,7 +157,7 @@ def build_govuk_search_tool(num_results: int = 1) -> Tool:
         return response
 
     @tool
-    def _search_govuk(query: str, state: Annotated[dict, InjectedState]) -> dict[str, Any]:
+    def _search_govuk(query: str, state: Annotated[dict, InjectedState], filter=filter) -> dict[str, Any]:
         """
         Search for documents on gov.uk based on a query string.
         This endpoint is used to search for documents on gov.uk. There are many types of documents on gov.uk.
@@ -186,7 +186,7 @@ def build_govuk_search_tool(num_results: int = 1) -> Tool:
             f"{url_base}/api/search.json",
             params={
                 "q": query,
-                "count": 10,
+                "count": 10 if filter else num_results,
                 "fields": required_fields,
             },
             headers={"Accept": "application/json"},
@@ -194,7 +194,9 @@ def build_govuk_search_tool(num_results: int = 1) -> Tool:
         response.raise_for_status()
         response = response.json()
 
-        response = recalculate_similarity(response, query, num_results)
+        if filter:
+            response = recalculate_similarity(response, query, num_results)
+
         mapped_documents = []
         for i, doc in enumerate(response["results"]):
             if any(field not in doc for field in required_fields):

--- a/redbox-core/redbox/graph/nodes/tools.py
+++ b/redbox-core/redbox/graph/nodes/tools.py
@@ -139,7 +139,7 @@ def build_search_documents_tool(
     return _search_documents
 
 
-def build_govuk_search_tool(num_results: int = 1) -> Tool:
+def build_govuk_search_tool(num_results: int = 1, filter=False) -> Tool:
     """Constructs a tool that searches gov.uk and sets state["documents"]."""
 
     tokeniser = tiktoken.encoding_for_model("gpt-4o")
@@ -186,7 +186,7 @@ def build_govuk_search_tool(num_results: int = 1) -> Tool:
             f"{url_base}/api/search.json",
             params={
                 "q": query,
-                "count": 10,
+                "count": 10 if filter else num_results,
                 "fields": required_fields,
             },
             headers={"Accept": "application/json"},
@@ -194,7 +194,8 @@ def build_govuk_search_tool(num_results: int = 1) -> Tool:
         response.raise_for_status()
         response = response.json()
 
-        response = recalculate_similarity(response, query, num_results)
+        if filter:
+            response = recalculate_similarity(response, query, num_results)
         mapped_documents = []
         for i, doc in enumerate(response["results"]):
             if any(field not in doc for field in required_fields):

--- a/redbox-core/tests/test_tools.py
+++ b/redbox-core/tests/test_tools.py
@@ -42,7 +42,9 @@ def test_is_valid_tool():
 
 def test_has_injected_state():
     @tool
-    def tool_with_injected_state(query: str, state: Annotated[dict, InjectedState]) -> dict[str, Any]:
+    def tool_with_injected_state(
+        query: str, state: Annotated[dict, InjectedState]
+    ) -> dict[str, Any]:
         """Tool that returns a dictionary update."""
         return {"key": "value"}
 
@@ -120,7 +122,9 @@ def test_search_documents_tool(
             "query": stored_file_parameterised.query.question,
             "state": RedboxState(
                 request=stored_file_parameterised.query,
-                messages=[HumanMessage(content=stored_file_parameterised.query.question)],
+                messages=[
+                    HumanMessage(content=stored_file_parameterised.query.question)
+                ],
             ),
         }
     )
@@ -139,12 +143,20 @@ def test_search_documents_tool(
 
         # Check flattened documents match expected, similar to retriever
         assert len(result_flat) == chain_params["rag_k"]
-        assert {c.page_content for c in result_flat} <= {c.page_content for c in permitted_docs}
-        assert {c.metadata["uri"] for c in result_flat} <= set(stored_file_parameterised.query.permitted_s3_keys)
+        assert {c.page_content for c in result_flat} <= {
+            c.page_content for c in permitted_docs
+        }
+        assert {c.metadata["uri"] for c in result_flat} <= set(
+            stored_file_parameterised.query.permitted_s3_keys
+        )
 
         if selected:
-            assert {c.page_content for c in result_flat} <= {c.page_content for c in selected_docs}
-            assert {c.metadata["uri"] for c in result_flat} <= set(stored_file_parameterised.query.s3_keys)
+            assert {c.page_content for c in result_flat} <= {
+                c.page_content for c in selected_docs
+            }
+            assert {c.metadata["uri"] for c in result_flat} <= set(
+                stored_file_parameterised.query.s3_keys
+            )
 
         # Check docstate is formed as expected, similar to transform tests
         for group_uuid, group_docs in result_docstate.items():
@@ -178,7 +190,10 @@ def test_govuk_search_tool():
     documents = flatten_document_state(state_update["documents"])
 
     # assert at least one document is travel advice
-    assert any("/foreign-travel-advice/cuba" in document.metadata["uri"] for document in documents)
+    assert any(
+        "/foreign-travel-advice/cuba" in document.metadata["uri"]
+        for document in documents
+    )
 
     for document in documents:
         assert document.page_content != ""
@@ -220,7 +235,7 @@ def test_wikipedia_tool():
         (True, True, "UK government use of AI", "artificial intelligence"),
     ],
 )
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_gov_filter_AI(is_filter, relevant_return, query, keyword):
     def run_tool(is_filter):
         tool = build_govuk_search_tool(num_results=1, filter=is_filter)
@@ -244,4 +259,7 @@ def test_gov_filter_AI(is_filter, relevant_return, query, keyword):
 
     # call gov tool without additional filter
     documents = run_tool(is_filter)
-    assert any(keyword in document.page_content for document in documents) == relevant_return
+    assert (
+        any(keyword in document.page_content for document in documents)
+        == relevant_return
+    )

--- a/redbox-core/tests/test_tools.py
+++ b/redbox-core/tests/test_tools.py
@@ -54,6 +54,7 @@ def test_has_injected_state():
     assert not has_injected_state(tool_without_injected_state)
 
 
+@pytest.mark.vcr()
 @pytest.mark.parametrize("chain_params", TEST_CHAIN_PARAMETERS)
 def test_search_documents_tool(
     chain_params: dict,

--- a/redbox-core/tests/test_tools.py
+++ b/redbox-core/tests/test_tools.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
 import pytest
+import requests
 from elasticsearch import Elasticsearch
 from langchain_core.embeddings.fake import FakeEmbeddings
 from langchain_core.messages import HumanMessage
@@ -212,7 +213,6 @@ def test_wikipedia_tool():
         assert metadata.creator_type == ChunkCreatorType.wikipedia
 
 
-@pytest.mark.vcr()
 @pytest.mark.parametrize(
     "is_filter, relevant_return, query, keyword",
     [
@@ -220,6 +220,7 @@ def test_wikipedia_tool():
         (True, True, "UK government use of AI", "artificial intelligence"),
     ],
 )
+@pytest.mark.vcr()
 def test_gov_filter_AI(is_filter, relevant_return, query, keyword):
     def run_tool(is_filter):
         tool = build_govuk_search_tool(num_results=1, filter=is_filter)

--- a/redbox-core/tests/test_tools.py
+++ b/redbox-core/tests/test_tools.py
@@ -54,7 +54,6 @@ def test_has_injected_state():
     assert not has_injected_state(tool_without_injected_state)
 
 
-@pytest.mark.vcr()
 @pytest.mark.parametrize("chain_params", TEST_CHAIN_PARAMETERS)
 def test_search_documents_tool(
     chain_params: dict,
@@ -213,6 +212,7 @@ def test_wikipedia_tool():
         assert metadata.creator_type == ChunkCreatorType.wikipedia
 
 
+@pytest.mark.vcr()
 @pytest.mark.parametrize(
     "is_filter, relevant_return, query, keyword",
     [

--- a/redbox-core/tests/test_tools.py
+++ b/redbox-core/tests/test_tools.py
@@ -16,9 +16,9 @@ from redbox.graph.nodes.tools import (
     has_injected_state,
     is_valid_tool,
 )
-from redbox.models.settings import Settings
 from redbox.models.chain import AISettings, RedboxQuery, RedboxState
 from redbox.models.file import ChunkCreatorType, ChunkMetadata, ChunkResolution
+from redbox.models.settings import Settings
 from redbox.test.data import RedboxChatTestCase
 from redbox.transform import flatten_document_state
 from tests.retriever.test_retriever import TEST_CHAIN_PARAMETERS
@@ -210,3 +210,36 @@ def test_wikipedia_tool():
         metadata = ChunkMetadata.model_validate(document.metadata)
         assert urlparse(metadata.uri).hostname == "en.wikipedia.org"
         assert metadata.creator_type == ChunkCreatorType.wikipedia
+
+
+@pytest.mark.parametrize(
+    "is_filter, relevant_return, query, keyword",
+    [
+        (False, False, "UK government use of AI", "artificial intelligence"),
+        (True, True, "UK government use of AI", "artificial intelligence"),
+    ],
+)
+def test_gov_filter_AI(is_filter, relevant_return, query, keyword):
+    def run_tool(is_filter):
+        tool = build_govuk_search_tool(num_results=1, filter=is_filter)
+        state_update = tool.invoke(
+            {
+                "query": query,
+                "state": RedboxState(
+                    request=RedboxQuery(
+                        question=query,
+                        s3_keys=[],
+                        user_uuid=uuid4(),
+                        chat_history=[],
+                        ai_settings=AISettings(),
+                        permitted_s3_keys=[],
+                    )
+                ),
+            }
+        )
+
+        return flatten_document_state(state_update["documents"])
+
+    # call gov tool without additional filter
+    documents = run_tool(is_filter)
+    assert any(keyword in document.page_content for document in documents) == relevant_return


### PR DESCRIPTION
## Context

GOV search API returns irrelevant pages resulting in incorrect documents to LLM. Example:
Using web search: [Search](https://www.gov.uk/search/all?keywords=UK+government+use+of+AI&order=relevance) 
Using API: https://www.gov.uk/api/search.json?q=UK+government+use+of+AI

Current findings:
The results from GOV search API is different from the results from search in the website i.e. [Search - GOV.UK](https://www.gov.uk/search) 
GOV search API returns pages with relevance score (es_score). However, the scores are higher for irrelevant pages. For example, a page about HMRC  has score of 0.434618 while DSIT document on AI has score of 0.08396282. 

## Changes proposed in this pull request

- Add a function to recalculate similarity between query and page description. I use a simple technique i.e. `cosine_similarity` from scikit-learn, to calculate similarity.  

## Guidance to review

There are other solutions to this. For example:
- Add all pages as document, and do elastic search. However, we would potentially be adding irrelevant docs.

## Relevant links


## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
