### PR TITLE
Add expand/collapse button for activity

### DIFF
--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -244,14 +244,30 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
 }
 
 .rb-activity {
+  position: relative;
+}
+.rb-activity__btn button {
+  background-color: transparent;
+  border: 0;
+  color: var(--iai-product-colour);
+  cursor: pointer;
+  font-size: 0.75rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.rb-activity__item {
   border-left: 1px solid black;
-  display: flex;
+  display: none;
   font-size: 0.75rem;
   margin: 0;
   margin-left: 0.5rem;
   padding-bottom: 0.75rem;
 }
-.rb-activity::before {
+.rb-activity__item:last-child, .rb-activity:has([expanded="true"]) .rb-activity__item {
+  display: flex;
+}
+.rb-activity__item::before {
   align-items: center;
   border-radius: 100%;
   content: '';
@@ -263,14 +279,14 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
   top: -1px;
   width: 1rem;
 }
-.rb-activity--user::before {
+.rb-activity__item--user::before {
   background-color: #0b8478;
   content: url("/static/icons/activity-user.svg")
 }
-.rb-activity--info::before {
+.rb-activity__item--info::before {
   background-color: #0779c4;
 }
-.rb-activity--ai::before {
+.rb-activity__item--ai::before {
   background-color: #9c0000;
   content: url("/static/icons/activity-redbox.svg")
 }

--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -270,6 +270,8 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
   margin: 0;
   margin-left: 0.5rem;
   padding-bottom: 0.75rem;
+  padding-right: 8rem;
+  word-break: break-word;
 }
 .rb-activity__item:last-child, .rb-activity:has([expanded="true"]) .rb-activity__item {
   display: flex;

--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -246,6 +246,13 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
 .rb-activity {
   position: relative;
 }
+.rb-activity__btn {
+  display: none;
+}
+/* Only show the expand/collapse button when there is more than one activity */
+.rb-activity:has(.rb-activity__item:nth-of-type(2)) .rb-activity__btn {
+  display: block;
+}
 .rb-activity__btn button {
   background-color: transparent;
   border: 0;

--- a/django_app/frontend/src/js/chats.js
+++ b/django_app/frontend/src/js/chats.js
@@ -1,3 +1,4 @@
+import "./web-components/chats/activity-button.js";
 import "./web-components/chats/chat-controller.js";
 import "./web-components/chats/chat-history.js";
 import "./web-components/chats/chat-history-item.js";

--- a/django_app/frontend/src/js/trusted-types.js
+++ b/django_app/frontend/src/js/trusted-types.js
@@ -11,6 +11,7 @@ if (typeof window.trustedTypes !== "undefined") {
         RETURN_TRUSTED_TYPE: false,
         CUSTOM_ELEMENT_HANDLING: {
           tagNameCheck: (tagName) =>
+            tagName === "activity-button" ||
             tagName === "copy-text" ||
             tagName === "feedback-buttons" ||
             tagName === "loading-message" ||

--- a/django_app/frontend/src/js/web-components/chats/activity-button.js
+++ b/django_app/frontend/src/js/web-components/chats/activity-button.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+class ActivityButton extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <button type="button">+ Show all activity</button>
+    `;
+
+    let button = this.querySelector("button");
+    button?.addEventListener("click", () => {
+      if (!button) {
+        return;
+      }
+      const expanded = button?.getAttribute("expanded") === "true" ? false : true;
+      button.setAttribute("expanded", expanded ? "true" : "false");
+      button.textContent = expanded ? "- Hide all activity" : "+ Show all activity";
+    });
+
+  }
+
+}
+customElements.define("activity-button", ActivityButton);

--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -36,41 +36,44 @@ export class ChatMessage extends HTMLElement {
   connectedCallback() {
     const uuid = crypto.randomUUID();
     this.innerHTML = `
-            <div class="iai-chat-bubble govuk-body {{ classes }}" data-role="${
-              this.dataset.role
-            }" tabindex="-1">
-                <div class="iai-chat-bubble__header">
-                    <div class="iai-chat-bubble__role">${
-                      this.dataset.role === "ai" ? "Redbox" : "You"
-                    }</div>
-                </div>
-                <markdown-converter class="iai-chat-bubble__text">${
-                  this.dataset.text || ""
-                }</markdown-converter>
-                ${
-                  !this.dataset.text
-                    ? `
-                      <loading-message data-aria-label="Loading message"></loading-message>
-                      <div class="rb-loading-complete govuk-visually-hidden" aria-live="assertive"></div>
-                    `
-                    : ""
-                }
-                <sources-list data-id="${uuid}"></sources-list>
-                <div class="govuk-notification-banner govuk-notification-banner--error govuk-!-margin-bottom-3 govuk-!-margin-top-3" role="alert" aria-labelledby="notification-title-${uuid}" data-module="govuk-notification-banner" hidden>
-                    <div class="govuk-notification-banner__header">
-                        <h3 class="govuk-notification-banner__title" id="notification-title-${uuid}">Error</h3>
-                    </div>
-                    <div class="govuk-notification-banner__content">
-                        <p class="govuk-notification-banner__heading"></p>
-                    </div>
-                </div>
-            </div>
-        `;
+      <div class="rb-activity">
+        <activity-button class="rb-activity__btn"></activity-button>
+      </div>
+      <div class="iai-chat-bubble govuk-body {{ classes }}" data-role="${
+        this.dataset.role
+      }" tabindex="-1">
+          <div class="iai-chat-bubble__header">
+              <div class="iai-chat-bubble__role">${
+                this.dataset.role === "ai" ? "Redbox" : "You"
+              }</div>
+          </div>
+          <markdown-converter class="iai-chat-bubble__text">${
+            this.dataset.text || ""
+          }</markdown-converter>
+          ${
+            !this.dataset.text
+              ? `
+                <loading-message data-aria-label="Loading message"></loading-message>
+                <div class="rb-loading-complete govuk-visually-hidden" aria-live="assertive"></div>
+              `
+              : ""
+          }
+          <sources-list data-id="${uuid}"></sources-list>
+          <div class="govuk-notification-banner govuk-notification-banner--error govuk-!-margin-bottom-3 govuk-!-margin-top-3" role="alert" aria-labelledby="notification-title-${uuid}" data-module="govuk-notification-banner" hidden>
+              <div class="govuk-notification-banner__header">
+                  <h3 class="govuk-notification-banner__title" id="notification-title-${uuid}">Error</h3>
+              </div>
+              <div class="govuk-notification-banner__content">
+                  <p class="govuk-notification-banner__heading"></p>
+              </div>
+          </div>
+      </div>
+  `;
 
     // Add feedback buttons
     if (this.dataset.role === "ai") {
       this.feedbackButtons = /** @type {import("./feedback-buttons").FeedbackButtons} */(document.createElement("feedback-buttons"));
-      this.parentElement?.appendChild(this.feedbackButtons);
+  this.parentElement?.appendChild(this.feedbackButtons);
     }
 
     // ensure new chat-messages aren't hidden behind the chat-input
@@ -88,6 +91,7 @@ export class ChatMessage extends HTMLElement {
       "mouseover",
       sendTooltipViewEvent
     );
+
   }
 
   #addFootnotes = (content) => {
@@ -121,9 +125,9 @@ export class ChatMessage extends HTMLElement {
    */
   addActivity = (message, type) => {
     let activityElement = document.createElement("p");
-    activityElement.classList.add("rb-activity", `rb-activity--${type}`);
+    activityElement.classList.add("rb-activity__item", `rb-activity__item--${type}`);
     activityElement.textContent = message;
-    this.insertBefore(activityElement, this.querySelector(".iai-chat-bubble"));
+    this.querySelector(".rb-activity")?.appendChild(activityElement);
   };
 
   /**

--- a/django_app/frontend/tests-web-components/activity-button.spec.js
+++ b/django_app/frontend/tests-web-components/activity-button.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+const { sendMessage, signIn } = require("./utils.js");
+
+test(`The activity log can be expanded when there is more than one item`, async ({ page }) => {
+  await signIn(page);
+
+  await page.goto("/chats");
+
+  await sendMessage(page);
+
+  // The first button is hidden, as there's only 1 user item
+  await expect(page.locator("activity-button button").first()).toBeHidden();
+
+  // The first AI log item is hidden, as there's more than 1 AI item
+  await expect(page.locator(".rb-activity__item--ai").first()).toBeHidden();
+
+  // Clicking the expand button shows all AI items
+  await page.locator("activity-button button").nth(1).click();
+  await expect(page.locator(".rb-activity__item--ai").first()).toBeVisible();
+
+});

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -36,9 +36,12 @@
 {% set role_text = "You" %}
 {% endif %}
 
-{% for activity in message.activityevent_set.all() %}
-  <p class="rb-activity rb-activity--{{ message.role }}">{{ activity }}</p>
-{% endfor %}
+<div class="rb-activity">
+  <activity-button class="rb-activity__btn"></activity-button>
+  {% for activity in message.activityevent_set.all() %}
+    <p class="rb-activity__item rb-activity__item--{{ message.role }}">{{ activity }}</p>
+  {% endfor %}
+</div>
 
 <div
   class="iai-chat-bubble govuk-body {{ classes }}"


### PR DESCRIPTION
## Context

So we can test a design concept with the activity log.


## Changes proposed in this pull request

Add button to the right. When it's not expanded, it will only show the latest activity

![image](https://github.com/user-attachments/assets/e9dba751-a5dc-40ca-943a-94e0cdbeed84)

![image](https://github.com/user-attachments/assets/c4602f7a-84c1-4b03-9e8a-3c4780fc51bc)

It won't show if there's only one item in the log


## Guidance to review

Send a message, click the button


## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
