### PR TITLE
Using elastic alias in gadget search documents 

### DIFF
--- a/redbox-core/redbox/app.py
+++ b/redbox-core/redbox/app.py
@@ -57,7 +57,7 @@ class Redbox:
 
         search_documents = build_search_documents_tool(
             es_client=_env.elasticsearch_client(),
-            index_name=f"{_env.elastic_root_index}-chunk",
+            index_name=_env.elastic_chunk_alias,
             embedding_model=self.embedding_model,
             embedding_field_name=_env.embedding_document_field_name,
             chunk_resolution=ChunkResolution.normal,


### PR DESCRIPTION
## Context

We're not getting any hits for new docs in preprod when using gadget. The search runs fine but returns no snippets. The logs have:

`POST https://2762b56ff0624e3a94dd274974183d10.eu-west-2.aws.cloud.es.io:443/redbox-data-preprod-chunk/_search`

which looks like we're not using the index alias on search_documents tool

## Changes proposed in this pull request

Create the search_documents tool with the index alias from settings

## Guidance to review

I haven't tested this locally as I can't reproduce it. I suspect the issue is that the index has never been rotated and so we don't have a mismatch between the alias and the index itself. I'll look into manually moving my alias over to see if this reproduces it but I'm confident this fix is correct as it bring the search_documents tool in line with the retriever

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
