### PR TITLE
Feature/tools return artefact

### DIFF
--- a/redbox-core/redbox/graph/nodes/tools.py
+++ b/redbox-core/redbox/graph/nodes/tools.py
@@ -12,6 +12,7 @@ from langchain_core.tools import Tool, tool
 from langgraph.prebuilt import InjectedState
 from sklearn.metrics.pairwise import cosine_similarity
 
+from redbox.api.format import format_documents
 from redbox.chains.components import get_embeddings
 from redbox.models.chain import RedboxState
 from redbox.models.file import ChunkCreatorType, ChunkMetadata, ChunkResolution
@@ -87,7 +88,7 @@ def build_search_documents_tool(
         sorted_documents = sort_documents(documents=merged_documents)
 
         # Return as state update
-        return "\n\n".join(map(str, sorted_documents)), sorted_documents
+        return format_documents(sorted_documents), sorted_documents
 
     return _search_documents
 
@@ -167,7 +168,7 @@ def build_govuk_search_tool(num_results: int = 1, filter=True) -> Tool:
                 )
             )
 
-        return "\n\n".join(map(str, mapped_documents)), mapped_documents
+        return format_documents(mapped_documents), mapped_documents
 
     return _search_govuk
 
@@ -208,7 +209,7 @@ def build_search_wikipedia_tool(number_wikipedia_results=1, max_chars_per_wiki_p
             for i, doc in enumerate(response)
         ]
         docs = mapped_documents
-        return "\n\n".join(map(str, docs)), docs
+        return format_documents(docs), docs
 
     return _search_wikipedia
 

--- a/redbox-core/redbox/graph/nodes/tools.py
+++ b/redbox-core/redbox/graph/nodes/tools.py
@@ -110,8 +110,8 @@ def build_govuk_search_tool(num_results: int = 1, filter=True) -> Tool:
         response["results"] = sorted(response.get("results"), key=lambda x: x["similarity"], reverse=True)[:num_results]
         return response
 
-    @tool
-    def _search_govuk(query: str, state: Annotated[RedboxState, InjectedState]) -> dict[str, Any]:
+    @tool(response_format="content_and_artifact")
+    def _search_govuk(query: str) -> tuple[str, list[Document]]:
         """
         Search for documents on gov.uk based on a query string.
         This endpoint is used to search for documents on gov.uk. There are many types of documents on gov.uk.
@@ -168,7 +168,7 @@ def build_govuk_search_tool(num_results: int = 1, filter=True) -> Tool:
                 )
             )
 
-        return {"documents": structure_documents_by_group_and_indices(mapped_documents)}
+        return "\n\n".join(map(str, mapped_documents)), mapped_documents
 
     return _search_govuk
 

--- a/redbox-core/redbox/graph/nodes/tools.py
+++ b/redbox-core/redbox/graph/nodes/tools.py
@@ -181,8 +181,8 @@ def build_search_wikipedia_tool(number_wikipedia_results=1, max_chars_per_wiki_p
     )
     tokeniser = tiktoken.encoding_for_model("gpt-4o")
 
-    @tool
-    def _search_wikipedia(query: str, state: Annotated[RedboxState, InjectedState]) -> dict[str, Any]:
+    @tool(response_format="content_and_artifact")
+    def _search_wikipedia(query: str) -> tuple[str, list[Document]]:
         """
         Search Wikipedia for information about the queried entity.
         Useful for when you need to answer general questions about people, places, objects, companies, facts, historical events, or other subjects.
@@ -208,7 +208,8 @@ def build_search_wikipedia_tool(number_wikipedia_results=1, max_chars_per_wiki_p
             )
             for i, doc in enumerate(response)
         ]
-        return {"documents": structure_documents_by_group_and_indices(mapped_documents)}
+        docs = mapped_documents
+        return "\n\n".join(map(str, docs)), docs
 
     return _search_wikipedia
 

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -157,7 +157,7 @@ def get_agentic_search_graph(tools: dict[str, StructuredTool], debug: bool = Fal
     builder = StateGraph(RedboxState)
     # Tools
     agent_tool_names = ["_search_documents", "_search_wikipedia", "_search_govuk"]
-    agent_tools: list[StructuredTool] = tuple([tools.get(tool_name) for tool_name in agent_tool_names])
+    agent_tools: list[StructuredTool] = [tools[tool_name] for tool_name in agent_tool_names]
 
     # Processes
     builder.add_node("p_set_agentic_search_route", build_set_route_pattern(route=ChatRoute.gadget))

--- a/redbox-core/tests/test_tools.py
+++ b/redbox-core/tests/test_tools.py
@@ -1,10 +1,10 @@
 from urllib.parse import urlparse
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 from elasticsearch import Elasticsearch
 from langchain_core.embeddings.fake import FakeEmbeddings
-from langchain_core.messages import HumanMessage, AIMessage
+from langchain_core.messages import AIMessage
 from langgraph.prebuilt import ToolNode
 
 from redbox.graph.nodes.tools import (
@@ -80,27 +80,35 @@ def test_search_documents_tool(
         chunk_resolution=ChunkResolution.normal,
     )
 
-    result_state = search.invoke(
-        {
-            "query": stored_file_parameterised.query.question,
-            "state": RedboxState(
-                request=stored_file_parameterised.query,
-                messages=[HumanMessage(content=stored_file_parameterised.query.question)],
-            ),
-        }
+    tool_node = ToolNode(tools=[search])
+    result_state = tool_node.invoke(
+        RedboxState(
+            request=stored_file_parameterised.query,
+            messages=[
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "_search_documents",
+                            "args": {"query": stored_file_parameterised.query.question},
+                            "id": "1",
+                        }
+                    ],
+                )
+            ],
+        )
     )
 
     if not permission:
         # No state update emitted
         assert result_state is None
     else:
-        result_docstate = result_state["documents"]
-        result_flat = flatten_document_state(result_state["documents"])
+        result_flat = result_state["messages"][0].artifact
+        # result_flat = flatten_document_state(result_state["messages"][0].artifact)
 
         # Check state update is formed as expected
         assert isinstance(result_state, dict)
         assert len(result_state) == 1
-        assert "documents" in result_state
 
         # Check flattened documents match expected, similar to retriever
         assert len(result_flat) == chain_params["rag_k"]
@@ -110,15 +118,6 @@ def test_search_documents_tool(
         if selected:
             assert {c.page_content for c in result_flat} <= {c.page_content for c in selected_docs}
             assert {c.metadata["uri"] for c in result_flat} <= set(stored_file_parameterised.query.s3_keys)
-
-        # Check docstate is formed as expected, similar to transform tests
-        for group_uuid, group_docs in result_docstate.groups.items():
-            assert isinstance(group_uuid, UUID)
-            assert isinstance(group_docs, dict)
-
-            for doc in group_docs.values():
-                assert doc.metadata["uuid"] in group_docs
-                assert group_docs[doc.metadata["uuid"]] == doc
 
 
 @pytest.mark.xfail(reason="calls openai")

--- a/redbox-core/tests/test_tools.py
+++ b/redbox-core/tests/test_tools.py
@@ -101,7 +101,7 @@ def test_search_documents_tool(
 
     if not permission:
         # No new messages update emitted
-        assert result_state["messages"][0].content is ""
+        assert result_state["messages"][0].content == ""
         assert result_state["messages"][0].artifact == []
     else:
         result_flat = result_state["messages"][0].artifact

--- a/redbox-core/tests/test_tools.py
+++ b/redbox-core/tests/test_tools.py
@@ -100,11 +100,11 @@ def test_search_documents_tool(
     )
 
     if not permission:
-        # No state update emitted
-        assert result_state is None
+        # No new messages update emitted
+        assert result_state["messages"][0].content is ""
+        assert result_state["messages"][0].artifact == []
     else:
         result_flat = result_state["messages"][0].artifact
-        # result_flat = flatten_document_state(result_state["messages"][0].artifact)
 
         # Check state update is formed as expected
         assert isinstance(result_state, dict)


### PR DESCRIPTION
## Context

As an Engineer I want to use the `content_and_artifact` approach to returning documents from tools where by each tool returns text that will be passes through to the LLM and documents which will be stored in the `ToolMessage.artefact`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
