### PR TITLE
Ignoring all blank strings from db AISettings when overriding

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -272,7 +272,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
         ai_settings["chat_backend"] = model_to_dict(chat.chat_backend)
 
         # we remove null values so that AISettings can populate them with defaults
-        ai_settings = {k: v for k, v in ai_settings.items() if v is not None}
+        ai_settings = {k: v for k, v in ai_settings.items() if v not in (None, "")}
         return AISettings.model_validate(ai_settings)
 
     async def handle_text(self, response: str) -> str:


### PR DESCRIPTION

## Context

We're getting blank prompts in some environments

## Changes proposed in this pull request

Ignore an override for a prompt in AISettings from the db if it's None or "" to avoid errors


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
