### PR TITLE
Add platform in .yml for Mac users installing unstructured

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   unstructured:
     image: quay.io/unstructured-io/unstructured-api:latest
+    platform: ${DOCKER_PLATFORM:-windows/amd64}
     ports:
       - 8000:8000
     networks:


### PR DESCRIPTION
## Context

As a AI engineer working on MAC, I need to be able to pull docker images suitable to my os architecture, so that I can run Redbox.

## Changes proposed in this pull request

- Add `platform` so that a user can specify their platform when install Redbox via `DOCKER_PLATFORM=linux/amd64 docker-compose up -d`

Alternatively,

- set your environment variable `DOCKER_PLATFORM` via `export DOCKER_PLATFORM=linux/amd64`, the use normal `docker compose up -d` 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
