### PR TITLE
Build new document-upload component

### DIFF
--- a/django_app/frontend/src/js/chats.js
+++ b/django_app/frontend/src/js/chats.js
@@ -6,6 +6,7 @@ import "./web-components/chats/chat-message.js";
 import "./web-components/chats/chat-title.js";
 import "./web-components/chats/copy-text.js";
 import "./web-components/chats/document-selector.js";
+import "./web-components/chats/document-upload.mjs";
 import "./web-components/chats/feedback-buttons.js";
 import "./web-components/markdown-converter.js";
 import "./web-components/chats/message-input.js";

--- a/django_app/frontend/src/js/web-components/chats/action-buttons.mjs
+++ b/django_app/frontend/src/js/web-components/chats/action-buttons.mjs
@@ -1,15 +1,8 @@
 // @ts-check
 import { LitElement, html } from "lit";
+import { RedboxElement } from "../redbox-element.mjs";
 
-class BaseElement extends LitElement {
-  // clear the SSR content and prevents Shadow DOM by default
-  createRenderRoot() {
-    this.innerHTML = "";
-    return this;
-  }
-}
-
-export class ActionButtons extends BaseElement {
+export class ActionButtons extends RedboxElement {
   static properties = {
     messageId: { type: String, attribute: 'data-id' },
     showRating: { type: Boolean, state: true },

--- a/django_app/frontend/src/js/web-components/chats/activity-button.mjs
+++ b/django_app/frontend/src/js/web-components/chats/activity-button.mjs
@@ -1,17 +1,8 @@
 // @ts-check
 import { LitElement, html } from "lit";
+import { RedboxElement } from "../redbox-element.mjs";
 
-
-class BaseElement extends LitElement {
-  // clear the SSR content and prevents Shadow DOM by default
-  createRenderRoot() {
-    this.innerHTML = "";
-    return this;
-  }
-}
-
-
-export class ActivityButton extends BaseElement {
+export class ActivityButton extends RedboxElement {
   static properties = {
     expanded: { type: Boolean, reflect: true },
   };
@@ -22,11 +13,7 @@ export class ActivityButton extends BaseElement {
   }
 
   render() {
-    return html`
-      <button @click=${this.#buttonClick} type="button">
-        ${this.expanded ? `- Hide all activity` : `+ Show all activity`}
-      </button>
-    `;
+    return html` <button @click=${this.#buttonClick} type="button">${this.expanded ? `- Hide all activity` : `+ Show all activity`}</button> `;
   }
 
   #buttonClick = () => {

--- a/django_app/frontend/src/js/web-components/chats/document-upload.mjs
+++ b/django_app/frontend/src/js/web-components/chats/document-upload.mjs
@@ -1,0 +1,89 @@
+// @ts-check
+import { LitElement, html } from "lit";
+import { RedboxElement } from "../redbox-element.mjs";
+
+export class DocumentUpload extends RedboxElement {
+  static properties = {
+    csrfToken: { type: String, attribute: "data-csrf-token" },
+    chatId: { type: String, attribute: "data-chat-id" },
+    dragDropInProgress: { type: Boolean, state: true },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    document.body.addEventListener("dragover", (evt) => {
+      evt.preventDefault();
+      window.clearTimeout(this.dragDropTimer);
+      this.dragDropInProgress = true;
+    });
+
+    document.body.addEventListener("drop", (evt) => {
+      evt.preventDefault();
+      this.dragDropInProgress = false;
+      const files = evt.dataTransfer?.files;
+      if (!files) {
+        return;
+      }
+      // copy files to the file-input element
+      const dataTransfer = new DataTransfer();
+      for (let i = 0; i < files.length; i++) {
+        dataTransfer.items.add(files[i]);
+      }
+      /** @type {HTMLInputElement} */ (this.querySelector("input[type=file]")).files = dataTransfer.files;
+      this.#sendFiles();
+    });
+
+    // this needs throttling, otherwise it will flicker
+    document.body.addEventListener("dragleave", (evt) => {
+      this.dragDropTimer = window.setTimeout(() => {
+        this.dragDropInProgress = false;
+      }, 1);
+    });
+  }
+
+  /**
+   * @param {SubmitEvent} [evt]
+   */
+  #sendFiles = async (evt) => {
+    evt?.preventDefault();
+    const formData = new FormData(this.querySelector("form") || undefined);
+    /*
+    for (let [key, value] of formData.entries()) {
+      console.log(key, value);
+    }
+    */
+    const response = await fetch("/upload/", {
+      method: "POST",
+      headers: {
+        "X-CSRFToken": this["csrfToken"],
+      },
+      body: formData,
+    });
+    if (!response.ok) {
+      // TO DO: Handle error
+    }
+    // TO DO: add document icons to the chat
+    /** @type {HTMLInputElement} */ (this.querySelector("input[type=file]")).value = "";
+  };
+
+  render() {
+    return html`
+      <form @submit=${this.#sendFiles} action="/upload/" method="post" enctype="multipart/form-data">
+        <input type="hidden" name="csrfmiddlewaretoken" value=${this["csrfToken"]} />
+        <input type="hidden" name="chat_id" value=${this["chatId"]} />
+        <label class="govuk-label" for="upload-docs">
+          <h3 class="govuk-heading-s">Add a document</h3>
+        </label>
+        <div id="upload-docs-notification">
+          <p class="govuk-body-l">The AI will use all documents you upload. You can use up to, and including, Official Sensitive documents. Do not upload any documents with personal data.</p>
+        </div>
+        <p class="govuk-body rb-file-types" id="upload-docs-filetypes">Limit 200MB per file: EML, HTML, JSON, MD, MSG, RST, RTF, TXT, XML, CSV, DOC, DOCX, EPUB, ODT, PDF, PPT, PPTX, TSV, XLSX, HTM</p>
+        <input class="govuk-file-upload" multiple id="upload-docs" name="uploadDocs" type="file" aria-describedby="upload-docs-notification upload-docs-filetypes" />
+        <button class="govuk-!-display-inline-block" type="submit">Upload</button>
+      </form>
+      ${this.dragDropInProgress ? html`<p>Drop files here to upload to chat</p>` : ""}
+    `;
+  }
+}
+customElements.define("document-upload", DocumentUpload);

--- a/django_app/frontend/src/js/web-components/redbox-element.mjs
+++ b/django_app/frontend/src/js/web-components/redbox-element.mjs
@@ -1,0 +1,13 @@
+/**
+ * This is the base class for all Lit Elements in Redbox
+ */
+
+import { LitElement } from "lit";
+
+export class RedboxElement extends LitElement {
+  // clear the SSR content and prevents Shadow DOM by default
+  createRenderRoot() {
+    this.innerHTML = "";
+    return this;
+  }
+}

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -21,6 +21,14 @@
     </div>
   </div>
 
+  {# Uncomment this is you would like to test #}
+  {#
+  {% set document_upload %}
+    <document-upload data-csrf-token="{{ csrf_token }}" data-chat-id="{{ chat_id }}"></document-upload>
+  {% endset %}
+  {{ document_upload | render_lit | safe }}
+  #}
+
   <form class="govuk-grid-row js-message-input" action="/post-message/" method="post">
 
     <div class="govuk-grid-column-one-third">

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -37,7 +37,7 @@
 {% endif %}
 
 <div class="rb-activity">
-  {{ '<activity-button class="rb-activity__btn"></activity-button>' | render_lit | safe }}
+  <activity-button class="rb-activity__btn"></activity-button>
   {% for activity in message.activityevent_set.all() %}
     <p class="rb-activity__item rb-activity__item--{{ message.role }}">{{ activity }}</p>
   {% endfor %}


### PR DESCRIPTION
## Context

In anticipation of the document-uploads being added to the chats page. This is the basic functionality, but no styling, error handling, or displaying of the uploaded files at the moment.

This is okay to be merged, as it's commented out in the HTML.


## Changes proposed in this pull request

* Create a `document-upload` component
* Prevent page reload when uploading a doc
* But support no-javascript fallback
* Add drag/drop support
* Creation of a `RedboxElement` base class to reduce boilerplate code


## Guidance to review

* Uncomment the section near the top of `chats.html`
* Upload files via drag-drop and the traditional way. They will then be visible on the documents page and available to chat with as normal


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
