### PR TITLE
Improve display of code in messages

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -47,9 +47,7 @@ export class ChatMessage extends HTMLElement {
                 this.dataset.role === "ai" ? "Redbox" : "You"
               }</div>
           </div>
-          <markdown-converter class="iai-chat-bubble__text">${
-            this.dataset.text || ""
-          }</markdown-converter>
+          <markdown-converter class="iai-chat-bubble__text" data-role="${this.dataset.role}"></markdown-converter>
           ${
             !this.dataset.text
               ? `
@@ -69,6 +67,9 @@ export class ChatMessage extends HTMLElement {
           </div>
       </div>
     `;
+
+    // Add any existing markdown content - can't update directly to the above HTML string as user HTML may be removed
+    /** @type {import("../markdown-converter").MarkdownConverter} */(this.querySelector("markdown-converter")).update(this.dataset.text || "");
 
     // Add feedback buttons
     if (this.dataset.role === "ai") {

--- a/django_app/frontend/src/js/web-components/markdown-converter.js
+++ b/django_app/frontend/src/js/web-components/markdown-converter.js
@@ -14,6 +14,13 @@ export class MarkdownConverter extends HTMLElement {
       headerLevelStart: 3,
       tables: true,
     });
+    // escape any user-submitted HTML
+    if (this.dataset.role === "user") {
+      // escape the HTML tags
+      markdown = markdown.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      // mark them as code - flaky (because sometimes the HTML will be incomplete) so commented out for now
+      //markdown = markdown.replace(/&lt;([\w-]+)&gt;/g, '<span class="code">&lt;$1&gt;</span>');
+    }
     this.innerHTML = converter.makeHtml(markdown);
   }
 

--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -150,3 +150,8 @@ upload-button {
 .iai-chat-bubbles__sources-link:visited {
   color: var(--iai-product-colour, var(--iai-colour-brand));
 }
+.iai-chat-bubble__text code {
+  background-color: #f5ebeb;
+  display: inline;
+  padding: 0.125rem;
+}

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -53,7 +53,7 @@
     {% endif %}
   </div>
 
-  <markdown-converter class="iai-chat-bubble__text">{{ message.text }}</markdown-converter>
+  <markdown-converter class="iai-chat-bubble__text" data-role="{{ message.role }}">{{ message.text }}</markdown-converter>
   {% if message.unique_citation_uris() %}
   <h3 class="iai-chat-bubble__sources-heading govuk-heading-s govuk-!-margin-bottom-1">Sources</h3>
   <div class="iai-display-flex-from-desktop">


### PR DESCRIPTION
## Context

We've (okay, I've) never looked at optimising how we display code in messages. Until now...


## Changes proposed in this pull request

LLM responses used to look like this:

<img src="https://github.com/user-attachments/assets/b7d85b65-f763-425b-90f0-889661cc8b95" width="400"/>

They now look like this:

<img src="https://github.com/user-attachments/assets/2ebf313c-d8fb-4279-bbb7-6e6fce715d14" width="400"/>

User messages were even worse:

<img src="https://github.com/user-attachments/assets/18469017-0b45-43bc-b1f0-10ca3d888dad" width="400"/>

They now look like this:

<img src="https://github.com/user-attachments/assets/46b257a8-f935-46b7-8d08-bf854d338949" width="400"/>

I went down the rabbit hole of trying to style user code in the same way as for the responses, but it's a very difficult task to separate code from normal text content, especially considering it may not be well-formed and could be in a variety of different programming languages. We could explore further, but I don't feel the reward would be worth the effort.


## Guidance to review

Ask a code-related question. Does it look okay?


## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
