### PR TITLE
Change "Sign in" to "Log in"

### DIFF
--- a/django_app/frontend/tests-web-components/utils.js
+++ b/django_app/frontend/tests-web-components/utils.js
@@ -3,7 +3,7 @@ const { exec } = require("child_process");
 require("dotenv").config();
 
 const signIn = async (page) => {
-  await page.goto("/sign-in");
+  await page.goto("/log-in");
 
   // Perform login actions
   await page.fill("#email", process.env.FROM_EMAIL);

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -27,11 +27,10 @@ from redbox.models.chain import (
     metadata_reducer,
 )
 from redbox.models.chain import Citation as AICitation
-from redbox.models.graph import RedboxActivityEvent
 from redbox.retriever import DjangoFileRetriever
 from redbox_app.redbox_core import error_messages
+from redbox_app.redbox_core.models import AISettings as AISettingsModel
 from redbox_app.redbox_core.models import (
-    ActivityEvent,
     Chat,
     ChatLLMBackend,
     ChatMessage,
@@ -39,7 +38,6 @@ from redbox_app.redbox_core.models import (
     Citation,
     File,
 )
-from redbox_app.redbox_core.models import AISettings as AISettingsModel
 
 User = get_user_model()
 OptFileSeq = Sequence[File] | None

--- a/django_app/redbox_app/redbox_core/views/auth_views.py
+++ b/django_app/redbox_app/redbox_core/views/auth_views.py
@@ -27,13 +27,11 @@ def sign_in_view(request: HttpRequest):
 
             try:
                 user = User.objects.get(email=email)
-                link = MagicLink.objects.create(
-                    user=user, redirect_to="/check-demographics"
-                )  # Switch this to "/chats" once profile overlay is added to Chats page
+                link = MagicLink.objects.create(user=user, redirect_to="/chats")
                 full_link = request.build_absolute_uri(link.get_absolute_url())
                 body = render_to_string("email/verification.txt", {"url": full_link})
                 send_mail(
-                    subject="Redbox sign-in",
+                    subject="Redbox log-in",
                     message=body,
                     from_email=settings.FROM_EMAIL,
                     recipient_list=[email],
@@ -43,7 +41,7 @@ def sign_in_view(request: HttpRequest):
             except HTTPError as e:
                 logger.exception("failed to send link to %s", email, exc_info=e)
 
-            return redirect("sign-in-link-sent")
+            return redirect("log-in-link-sent")
 
         return render(
             request,

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -169,10 +169,10 @@ if LOGIN_METHOD == "sso":
 elif LOGIN_METHOD == "magic_link":
     SESSION_COOKIE_SAMESITE = "Strict"
     LOGIN_REDIRECT_URL = "homepage"
-    LOGIN_URL = "sign-in"
+    LOGIN_URL = "log-in"
 else:
     LOGIN_REDIRECT_URL = "homepage"
-    LOGIN_URL = "sign-in"
+    LOGIN_URL = "log-in"
 
 # CSP settings https://content-security-policy.com/
 # https://django-csp.readthedocs.io/

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -69,7 +69,7 @@
           "initials": request.user.get_initials(),
           "menu_items": [
               {"text": "My details", "href": url('demographics')},
-              {"text": "Sign out", "href": url('signed-out')}
+              {"text": "Log out", "href": url('logged-out')}
           ]
       },
       phase = "Beta"
@@ -78,7 +78,7 @@
     {{ iaiTopNav(
       product_name = "Redbox",
       menu_items = [
-        {"text": "Sign in", "href": url('sign-in')}
+        {"text": "Log in", "href": url('log-in')}
       ],
       phase = "Beta"
     ) }}

--- a/django_app/redbox_app/templates/email/verification.txt
+++ b/django_app/redbox_app/templates/email/verification.txt
@@ -1,6 +1,6 @@
 Hi,
 
-You can use the following link to sign in to your Redbox account:
+You can use the following link to log in to your Redbox account:
 {{url|safe}}
 
 You can only use this link once. If you do not use it within 5 minutes, it will expire.

--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -14,8 +14,8 @@
                     <div class="rb-banner__links">
                         {% if not request.user.is_authenticated %}
                             {{ govukButton(
-                                text="Sign in",
-                                href=url('sign-in'),
+                                text="Log in",
+                                href=url('log-in'),
                                 classes="govuk-button--secondary govuk-!-margin-bottom-0 rb-banner__button"
                             ) }}
                         {% endif %}
@@ -26,8 +26,8 @@
                     <div class="rb-banner__links">
                         {% if not request.user.is_authenticated %}
                             {{ govukButton(
-                                text="Sign in",
-                                href=url('sign-in'),
+                                text="Log in",
+                                href=url('log-in'),
                                 classes="govuk-button--secondary govuk-!-margin-bottom-0 rb-banner__button"
                             ) }}
                             {% if allow_sign_ups %}

--- a/django_app/redbox_app/templates/magic_link/error.html
+++ b/django_app/redbox_app/templates/magic_link/error.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Sign in - confirmation" %}
+{% set pageTitle = "Log in - error" %}
 
 {% extends "base.html" %}
 
@@ -8,9 +8,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
   
-      <h1 class="govuk-heading-l">Sign in - error</h1>
-      <p class="govuk-body">There was a problem signing in: {{ error }}</p>
-      <p class="govuk-body">Please try to <a class="govuk-link" href="{{ url('sign-in') }}">sign in</a> again.</p>
+      <h1 class="govuk-heading-l">Log in - error</h1>
+      <p class="govuk-body">There was a problem logging in: {{ error }}</p>
+      <p class="govuk-body">Please try to <a class="govuk-link" href="{{ url('log-in') }}">log in</a> again.</p>
   
     </div>
   </div>

--- a/django_app/redbox_app/templates/magic_link/logmein.html
+++ b/django_app/redbox_app/templates/magic_link/logmein.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Sign in - confirmation" %}
+{% set pageTitle = "Log in - confirmation" %}
 
 {% extends "base.html" %}
 {% from "macros/govuk-button.html" import govukButton %}

--- a/django_app/redbox_app/templates/sign-in-link-sent.html
+++ b/django_app/redbox_app/templates/sign-in-link-sent.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Sign in - link sent" %}
+{% set pageTitle = "Log in - link sent" %}
 
 {% extends "base.html" %}
 
@@ -8,8 +8,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
   
-      <h1 class="govuk-heading-l">Sign in - link sent</h1>
-      <p class="govuk-body">If you have previously registered, please check your emails for a link to sign in.</p>
+      <h1 class="govuk-heading-l">Log in - link sent</h1>
+      <p class="govuk-body">If you have previously registered, please check your emails for a link to log in.</p>
   
     </div>
   </div>

--- a/django_app/redbox_app/templates/sign-in.html
+++ b/django_app/redbox_app/templates/sign-in.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Sign in" %}
+{% set pageTitle = "Log in" %}
 
 {% extends "base.html" %}
 {% from "macros/govuk-button.html" import govukButton %}
@@ -9,9 +9,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">Sign in</h1>
+      <h1 class="govuk-heading-l">Log in</h1>
 
-      <form method="post" action="/sign-in/">
+      <form method="post" action="/log-in/">
 
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
 
@@ -20,7 +20,7 @@
             Email address
           </label>
           <div id="email-hint" class="govuk-hint">
-            Enter your email address to generate a link to sign in
+            Enter your email address to generate a link to log in
           </div>
           <input class="govuk-input" id="email" name="email" type="email" spellcheck="false" aria-describedby="email-hint" autocomplete="email" required>
         </div>

--- a/django_app/redbox_app/templates/sign-up-page-7.html
+++ b/django_app/redbox_app/templates/sign-up-page-7.html
@@ -42,7 +42,7 @@
         </ul>
 
         <div class="govuk-button-group govuk-!-margin-top-6">
-          {{ govukButton(text="Sign in to your Redbox", href=url('sign-in')) }}
+          {{ govukButton(text="Log in to your Redbox", href=url('log-in')) }}
         </div>
 
       </div>

--- a/django_app/redbox_app/templates/signed-out.html
+++ b/django_app/redbox_app/templates/signed-out.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Signed out" %}
+{% set pageTitle = "Logged out" %}
 
 {% extends "base.html" %}
 
@@ -8,8 +8,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      <h1 class="govuk-heading-l">You are signed out</h1>
-      <p class="govuk-body">To continue working please <a class="govuk-link" href="{{ url('sign-in') }}">sign in</a>.</p>
+      <h1 class="govuk-heading-l">You are logged out</h1>
+      <p class="govuk-body">To continue working please <a class="govuk-link" href="{{ url('log-in') }}">log in</a>.</p>
 
     </div>
   </div>

--- a/django_app/redbox_app/templates/sitemap.html
+++ b/django_app/redbox_app/templates/sitemap.html
@@ -18,7 +18,7 @@
                 {% endif %}
                 <li><a class="govuk-link" href="{{ url('privacy-notice') }}">Privacy</a></li>
                 {% if not request.user.is_authenticated %}
-                    <li><a class="govuk-link" href="{{ url('sign-in') }}">Sign in</a></li>
+                    <li><a class="govuk-link" href="{{ url('log-in') }}">Log in</a></li>
                 {% endif %}
                 <li><a class="govuk-link" href="{{ url('support') }}">Support</a></li>
             </ul>

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic.base import RedirectView
 from magic_link import urls as magic_link_urls
 
 from .redbox_core import views
@@ -13,13 +14,14 @@ admin.autodiscover()
 
 auth_urlpatterns = [
     path("magic_link/", include(magic_link_urls)),
-    path("sign-in/", views.sign_in_view, name="sign-in"),
+    path("log-in/", views.sign_in_view, name="log-in"),
+    path("sign-in/", RedirectView.as_view(url="/log-in/")),
     path(
-        "sign-in-link-sent/",
+        "log-in-link-sent/",
         views.sign_in_link_sent_view,
-        name="sign-in-link-sent",
+        name="log-in-link-sent",
     ),
-    path("signed-out/", views.signed_out_view, name="signed-out"),
+    path("logged-out/", views.signed_out_view, name="logged-out"),
     path("sign-up-page-1", views.Signup1.as_view(), name="sign-up-page-1"),
     path("sign-up-page-2", views.Signup2.as_view(), name="sign-up-page-2"),
     path("sign-up-page-3", views.Signup3.as_view(), name="sign-up-page-3"),

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -18,12 +18,11 @@ from websockets import WebSocketClientProtocol
 from websockets.legacy.client import Connect
 
 from redbox.models.chain import LLMCallMetadata, RedboxQuery, RequestMetadata
-from redbox.models.graph import FINAL_RESPONSE_TAG, ROUTE_NAME_TAG, SOURCE_DOCUMENTS_TAG, RedboxActivityEvent
+from redbox.models.graph import FINAL_RESPONSE_TAG, ROUTE_NAME_TAG, SOURCE_DOCUMENTS_TAG
 from redbox.models.prompts import CHAT_MAP_QUESTION_PROMPT
 from redbox_app.redbox_core import error_messages
 from redbox_app.redbox_core.consumers import ChatConsumer
 from redbox_app.redbox_core.models import (
-    ActivityEvent,
     Chat,
     ChatMessage,
     ChatMessageTokenUse,

--- a/django_app/tests/views/test_auth_views.py
+++ b/django_app/tests/views/test_auth_views.py
@@ -16,12 +16,12 @@ def test_sign_in_view_redirect_to_sign_in(alice: User, client: Client, mailoutbo
     # Given a user that does exist in the db Alice
 
     # When
-    url = reverse("sign-in")
+    url = reverse("log-in")
     response = client.post(url, data={"email": alice.email})
 
     # Then
     assert response.status_code == HTTPStatus.FOUND
-    assert response.url == "/sign-in-link-sent/"
+    assert response.url == "/log-in-link-sent/"
     link = next(line for line in mailoutbox[-1].body.splitlines() if line.startswith("http"))
     signed_in_response = client.get(link)
     assert signed_in_response.status_code == HTTPStatus.OK
@@ -32,7 +32,7 @@ def test_sign_in_view_redirect_sign_up(client: Client):
     # Given a user that does not exist in the database
 
     # When
-    url = reverse("sign-in")
+    url = reverse("log-in")
     response = client.post(url, data={"email": "not.a.real.user@gov.uk"})
 
     # Then

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -117,7 +117,7 @@ We'll need to create a superuser to log in to the Django app, to do this run the
 1. Come up with an email to log in with. It doesn't need to be real.
 2. `docker compose run django-app venv/bin/django-admin createsuperuser`
 3. Use the email you came up with in step 1, and a password (the password isn't used as we use magic links).
-4. Now go to http://localhost:8090/sign-in/ enter the email you just created a super user for.
+4. Now go to http://localhost:8090/log-in/ enter the email you just created a super user for.
 5. Press "Continue"
 6. Now go to your terminal and run `docker compose logs django-app | grep 8090/magic_link`
 7. Click that link and you should be logged in.

--- a/docs/installation/local.md
+++ b/docs/installation/local.md
@@ -77,7 +77,7 @@ To create an admin user, you can run the following command:
 docker compose run django-app venv/bin/django-admin createsuperuser
 ```
 
-You will be prompted to enter an email and a password. These can be anything you like as the development mode doesn't send emails or use passwords for authentication. Instead we use magic links. Once the superuser is created, you can log in to the Django admin interface by navigating to [`http://localhost:8090/sign-in`](http://localhost:8090/sign-in) and entering the email you just created.
+You will be prompted to enter an email and a password. These can be anything you like as the development mode doesn't send emails or use passwords for authentication. Instead we use magic links. Once the superuser is created, you can log in to the Django admin interface by navigating to [`http://localhost:8090/log-in`](http://localhost:8090/log-in) and entering the email you just created.
 
 ![Redbox Sign In](../../assets/redbox_signin.png)
 

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -118,14 +118,14 @@ class LandingPage(BasePage):
         return "Redbox"
 
     def navigate_to_sign_in(self) -> "SignInPage":
-        self.page.get_by_role("link", name="Sign in", exact=True).click()
+        self.page.get_by_role("link", name="Log in", exact=True).click()
         return SignInPage(self.page)
 
 
 class SignInPage(BasePage):
     @property
     def expected_page_title(self) -> str:
-        return "Sign in - Redbox"
+        return "Log in - Redbox"
 
     @property
     def email(self) -> str:
@@ -143,11 +143,11 @@ class SignInPage(BasePage):
 class SignInLinkSentPage(BasePage):
     @property
     def expected_page_title(self) -> str:
-        return "Sign in - link sent - Redbox"
+        return "Log in - link sent - Redbox"
 
 
 class SignInConfirmationPage(BasePage):
-    EXPECTED_TITLE = "Sign in - confirmation - Redbox"
+    EXPECTED_TITLE = "Log in - confirmation - Redbox"
 
     def __init__(self, page, magic_link: URL):
         page.goto(str(magic_link))


### PR DESCRIPTION
## Context

The new designs will have "Log in" (rather than "Sign in") to make a clearer distinction from "Sign up". This is a change we can make now.


## Changes proposed in this pull request

* Changed "Sign in" and "Sign out" text references to "Log in" and "Log out"
* Have done the same for any URLs
* Added a redirect for `/sign-in/`


## Guidance to review

* Check logging-in and logging-out works okay
* Check all user-facing references have been updated (I felt renaming the views was unnecessary, but I can do it you feel it would be better)
* Check using `/sign-in/` redirects properly


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
