### PR TITLE
Allow deletion of documents on chats page

### DIFF
--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -826,9 +826,13 @@ main:has(.iai-chat-bubble[data-role="ai"]) .exit-feedback {
 
 .rb-uploaded-docs {
   display: none;
+  justify-content: flex-end;
 }
 .rb-uploaded-docs:has(li) {
-  display: block;
+  display: flex;
+}
+.rb-uploaded-docs__item {
+  list-style-type: none;
 }
 .rb-uploaded-docs__drag-drop-message {
   background-color: rgba(255, 255, 255, 0.9);

--- a/django_app/frontend/src/js/chats.js
+++ b/django_app/frontend/src/js/chats.js
@@ -14,9 +14,8 @@ import "./web-components/chats/message-input.js";
 import "./web-components/chats/model-selector.mjs";
 import "./web-components/chats/canned-prompts";
 import "./web-components/chats/send-message.js";
-import "./web-components/chats/profile-overlay.js";
 import "./web-components/documents/file-status.js";
-import "./web-components/chats/profile-overlay.js";
+import "./web-components/chats/upload-container.mjs";
 import "./web-components/chats/exit-feedback.js";
 
 document.addEventListener("chat-response-end", (evt) => {

--- a/django_app/frontend/src/js/web-components/chats/chat-controller.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-controller.js
@@ -28,6 +28,9 @@ class ChatController extends HTMLElement {
       userMessage.setAttribute("data-role", "user");
       messageContainer?.insertBefore(userMessage, insertPosition);
 
+      let documentContainer = document.createElement("document-container");
+      messageContainer?.insertBefore(documentContainer, insertPosition);
+
       let aiMessage = /** @type {import("./chat-message").ChatMessage} */ (
         document.createElement("chat-message")
       );

--- a/django_app/frontend/src/js/web-components/chats/document-container.mjs
+++ b/django_app/frontend/src/js/web-components/chats/document-container.mjs
@@ -7,49 +7,18 @@ export class DocumentContainer extends RedboxElement {
     docs: { type: Array, attribute: "data-docs" },
   };
 
-  async addDocument(doc, csrfToken) {
-  
-    const tempId = crypto.randomUUID();
-
-    this.docs.push({
-      temp_id: tempId,
-      file_name: doc.name,
-      status: "Uploading"
-    });
+  async addDocuments(docs) {
+    this.docs = docs;
     this.requestUpdate();
-
-    const formData = new FormData();
-    formData.append('file', doc);
-    formData.append('chat_id', this.dataset.chatid);
-
-    const response = await fetch("/api/v0/file/", {
-      method: "POST",
-      headers: {
-        "X-CSRFToken": csrfToken,
-      },
-      body: formData,
-    });
-    if (!response.ok) {
-      // TO DO: Handle error
-    }
-
-    const data = await response.json();
-    this.docs.find(doc => doc.temp_id === tempId).id = data.file_id;
-    this.requestUpdate();
-
   }
 
   render() {
     return html`
       <div class="rb-uploaded-docs">
-        <h3>Uploaded documents</h3>
         <ul>
-          ${this.docs.map(
+          ${this.docs?.map(
             (doc) => html`
-              <li>
-                ${doc.file_name} : 
-                <file-status data-id=${doc.id}>${doc.file_status}</file-status>
-              </li>
+              <li class="rb-uploaded-docs__item iai-chat-bubble">${doc.file_name}</li>
             `
           )}
         </ul>

--- a/django_app/frontend/src/js/web-components/chats/document-upload.mjs
+++ b/django_app/frontend/src/js/web-components/chats/document-upload.mjs
@@ -4,7 +4,7 @@ import { RedboxElement } from "../redbox-element.mjs";
 
 export class DocumentUpload extends RedboxElement {
   static properties = {
-    csrfToken: { type: String, attribute: "data-csrf-token" },
+    csrfToken: { type: String, attribute: "data-csrftoken" },
     chatId: { type: String, attribute: "data-chatid" },
     dragDropInProgress: { type: Boolean, state: true },
   };
@@ -62,11 +62,10 @@ export class DocumentUpload extends RedboxElement {
 
     evt?.preventDefault();
 
-    const allUploadedDocContainers = document.querySelectorAll("document-container");
-    const lastUploadedDocContainer = allUploadedDocContainers[allUploadedDocContainers.length - 1];
+    const uploadContainer = document.querySelector("upload-container");
 
     for (const doc of /** @type {HTMLFormElement} */(this.querySelector("input[type=file]")).files) {
-      lastUploadedDocContainer.addDocument(doc, this.csrfToken);
+      uploadContainer.addDocument(doc);
     }
 
     this.querySelector("input[type=file]").value = "";

--- a/django_app/frontend/src/js/web-components/chats/model-selector.mjs
+++ b/django_app/frontend/src/js/web-components/chats/model-selector.mjs
@@ -26,7 +26,7 @@ export class ModelSelector extends RedboxElement {
   render() {
     if (this.jsInitialised) {
       return html`
-        <div class="rb-model-selector__select" @click=${this.#toggle} @keydown=${this.#keypress} @blur=${this.#blur} aria-controls="models-list" aria-expanded=${this.expanded ? "true" : "false"} aria-haspopup="listbox" aria-label="Model" id="llm-selector" role="combobox" tabindex="0" aria-activedescendant="model-option-${this.activeOption}">
+        <div class="rb-model-selector__select" @click=${this.#toggle} @keydown=${this.#keypress} @blur=${this.#blur} aria-controls="models-list" aria-expanded=${this.expanded ? "true" : "false"} aria-haspopup="listbox" aria-label="Model" role="combobox" tabindex="0" aria-activedescendant="model-option-${this.activeOption}">
           ${this.options[this.selectedOption].name}
           <span aria-hidden="true">${this.expanded ? "▲" : "▼"}</span>
         </div>
@@ -41,6 +41,7 @@ export class ModelSelector extends RedboxElement {
               `)}
             </div>
         ` : nothing}
+        <input type="hidden" id="llm-selector" name="llm" value=${this.options[this.selectedOption].id}/>
       `;
     }
     return html`

--- a/django_app/frontend/src/js/web-components/chats/upload-container.mjs
+++ b/django_app/frontend/src/js/web-components/chats/upload-container.mjs
@@ -1,0 +1,92 @@
+// @ts-check
+import { LitElement, html } from "lit";
+import { RedboxElement } from "../redbox-element.mjs";
+
+export class UploadContainer extends RedboxElement {
+  static properties = {
+    docs: { type: Array, attribute: "data-docs" },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    // on message-send move the uploaded docs to the correct container
+    document.addEventListener("chat-response-start", () => {
+      const documentContainers = document.querySelectorAll("document-container");
+      const lastDocumentContainer = documentContainers[documentContainers.length - 1];
+      lastDocumentContainer.addDocuments(this.docs);
+      this.docs = [];
+    });
+  }
+
+  render() {
+    return html`
+      <div class="rb-uploaded-docs">
+        <h3>Uploaded documents</h3>
+        <ul>
+          ${this.docs.map(
+            (doc) => html`
+              <li>
+                ${doc.file_name} : 
+                <file-status data-id=${doc.id}>${doc.file_status}</file-status>
+                <button @click=${this.#remove}>Remove</button>
+              </li>
+            `
+          )}
+        </ul>
+      </div>
+    `;
+  }
+
+  async addDocument(doc) {
+  
+    const tempId = crypto.randomUUID();
+
+    this.docs.push({
+      temp_id: tempId,
+      file_name: doc.name,
+      status: "Uploading"
+    });
+    this.requestUpdate();
+
+    const formData = new FormData();
+    formData.append('file', doc);
+    formData.append('chat_id', this.dataset.chatid);
+
+    const response = await fetch("/api/v0/file/", {
+      method: "POST",
+      headers: {
+        "X-CSRFToken": this.dataset.csrftoken,
+      },
+      body: formData,
+    });
+    if (!response.ok) {
+      // TO DO: Handle error
+    }
+
+    const data = await response.json();
+    this.docs.find(doc => doc.temp_id === tempId).id = data.file_id;
+    this.requestUpdate();
+
+  }
+
+  #remove = (evt) => {
+    const item = evt.target.parentNode;
+    const id = item.querySelector("file-status").dataset.id;
+    
+    // remove from UI
+    item.remove();
+
+    // remove from server
+    const formData = new FormData();
+    formData.append('doc_id', id);
+    fetch(`/remove-doc/${id}`, {
+      method: "POST",
+      headers: {
+        "X-CSRFToken": this.dataset.csrftoken,
+      },
+      body: formData,
+    });
+  }
+
+}
+customElements.define("upload-container", UploadContainer);

--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -88,7 +88,8 @@ def filter_docs(docs, messages, message_index):
     end_timestamp = datetime.datetime.now(pytz.timezone("Europe/London"))
     if message_index < messages.count():
         end_timestamp = messages[message_index].created_at
-    filtered_docs = [doc for doc in docs if start_timestamp < doc.created_at < end_timestamp]
+    active_docs = [doc for doc in docs if doc.get_status_text() != "Deleted"]
+    filtered_docs = [doc for doc in active_docs if start_timestamp < doc.created_at < end_timestamp]
     return json.dumps(
         [{"id": str(doc.id), "file_name": doc.file_name, "file_status": doc.get_status_text()} for doc in filtered_docs]
     )

--- a/django_app/redbox_app/templates/chats-test.html
+++ b/django_app/redbox_app/templates/chats-test.html
@@ -88,6 +88,9 @@
             {# SSR messages #}
             {% for message in messages %}
 
+              {{ message_box(message=message) }}
+
+              {# Display uploaded documents #}
               {% if message.role == 'user' %}
                 {% set uploaded_documents %}
                   <document-container data-chatid="{{ chat_id }}" data-docs="{{ current_chat.file_set.all() | filter_docs(messages, loop.index0) }}"></document-container>
@@ -95,19 +98,12 @@
                 {{ uploaded_documents | render_lit | safe }}
               {% endif %}
 
-              {{ message_box(message=message) }}
-
               {# Collect feedback on SSR messages #}
               {% if message.role == 'ai' %}
                 <feedback-buttons data-id="{{ message.id }}"></feedback-buttons>
               {% endif %}
 
             {% endfor %}
-
-            {% set uploaded_documents %}
-              <document-container data-chatid="{{ chat_id }}" data-docs="{{ current_chat.file_set.all() | filter_docs(messages, messages.count()) }}"></document-container>
-            {% endset %}
-            {{ uploaded_documents | render_lit | safe }}
 
             {# CSR messages are inserted here #}
 
@@ -125,9 +121,14 @@
       {% endif %}
 
       {% set document_upload %}
-        <document-upload data-csrf-token="{{ csrf_token }}" data-chatid="{{ chat_id }}"></document-upload>
+        <document-upload data-csrftoken="{{ csrf_token }}" data-chatid="{{ chat_id }}"></document-upload>
       {% endset %}
       {{ document_upload | render_lit | safe }}
+
+      {% set uploaded_documents %}
+        <upload-container data-chatid="{{ chat_id }}" data-csrftoken="{{ csrf_token }}" data-docs="{{ current_chat.file_set.all() | filter_docs(messages, messages.count()) }}"></upload-container>
+      {% endset %}
+      {{ uploaded_documents | render_lit | safe }}
 
       <form id="message-form" class="iai-chat-input" action="/post-message/" method="post">
         <div class="iai-chat-input__container">


### PR DESCRIPTION
## Context

We want to allow deletion of documents on the new chats page (until a new message has been sent)


## Changes proposed in this pull request

* Split `document-container` (previously uploaded docs) and `upload-container` (currently uploading docs) elements
* Style `document-container` items
* Add delete button to `document-container` items (to be styled properly in due course)


## Guidance to review

* Go to a new chat with `?test=true`
* Upload a doc and send a message


## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-986


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
