### PR TITLE
Tidy up lit components

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/attach-document.mjs
+++ b/django_app/frontend/src/js/web-components/chats/attach-document.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { LitElement, html } from "lit";
+import { html } from "lit";
 import { RedboxElement } from "../redbox-element.mjs";
 
 export class AttachDocument extends RedboxElement {

--- a/django_app/frontend/src/js/web-components/chats/document-container.mjs
+++ b/django_app/frontend/src/js/web-components/chats/document-container.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { LitElement, html } from "lit";
+import { html } from "lit";
 import { RedboxElement } from "../redbox-element.mjs";
 
 export class DocumentContainer extends RedboxElement {

--- a/django_app/frontend/src/js/web-components/chats/document-upload.mjs
+++ b/django_app/frontend/src/js/web-components/chats/document-upload.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { LitElement, html } from "lit";
+import { html } from "lit";
 import { RedboxElement } from "../redbox-element.mjs";
 
 export class DocumentUpload extends RedboxElement {

--- a/django_app/frontend/src/js/web-components/chats/model-selector.mjs
+++ b/django_app/frontend/src/js/web-components/chats/model-selector.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { LitElement, html, nothing } from "lit";
+import { html, nothing } from "lit";
 import { RedboxElement } from "../redbox-element.mjs";
 
 export class ModelSelector extends RedboxElement {

--- a/django_app/frontend/src/js/web-components/chats/upload-container.mjs
+++ b/django_app/frontend/src/js/web-components/chats/upload-container.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { LitElement, html } from "lit";
+import { html } from "lit";
 import { RedboxElement } from "../redbox-element.mjs";
 
 export class UploadContainer extends RedboxElement {

--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -4,6 +4,7 @@ import logging
 
 import humanize
 import jinja2
+import markupsafe
 import pytz
 import requests
 import waffle
@@ -72,9 +73,9 @@ def render_lit(html):
         response = requests.get(lit_ssr_url, timeout=1, params={"data": html})
         logger.info("status_code=%s", response.status_code)
         response.raise_for_status()
-        return response.text  # noqa: TRY300
+        return markupsafe.Markup(response.text)
     except requests.RequestException:
-        return html
+        return markupsafe.Markup(html)
 
 
 def filter_docs(docs, messages, message_index):

--- a/django_app/redbox_app/templates/chats-test.html
+++ b/django_app/redbox_app/templates/chats-test.html
@@ -60,7 +60,7 @@
           {% set model_selector %}
             <model-selector data-options="{{ llm_options | to_json }}"></model-selector>
           {% endset %}
-          {{ model_selector | render_lit | safe }}
+          {{ model_selector | render_lit }}
         </div>
 
       </div>
@@ -94,7 +94,7 @@
                 {% set uploaded_documents %}
                   <document-container data-chatid="{{ chat_id }}" data-docs="{{ current_chat.file_set.all() | filter_docs(messages, loop.index0) }}"></document-container>
                 {% endset %}
-                {{ uploaded_documents | render_lit | safe }}
+                {{ uploaded_documents | render_lit }}
               {% endif %}
 
               {# Collect feedback on SSR messages #}
@@ -122,12 +122,12 @@
       {% set document_upload %}
         <document-upload data-csrftoken="{{ csrf_token }}" data-chatid="{{ chat_id }}"></document-upload>
       {% endset %}
-      {{ document_upload | render_lit | safe }}
+      {{ document_upload | render_lit }}
 
       {% set uploaded_documents %}
         <upload-container data-chatid="{{ chat_id }}" data-csrftoken="{{ csrf_token }}" data-docs="{{ current_chat.file_set.all() | filter_docs(messages, messages.count()) }}"></upload-container>
       {% endset %}
-      {{ uploaded_documents | render_lit | safe }}
+      {{ uploaded_documents | render_lit }}
 
       <form id="message-form" class="iai-chat-input" action="/post-message/" method="post">
         <div class="iai-chat-input__container">

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -14,13 +14,5 @@
 {% if message.role == "ai" %}
   <copy-text></copy-text>
 {% endif %}
-{#
-{% if message.role == "ai" %}
-  {% set html %}
-    <action-buttons message-id="{{ message.id }}"></action-buttons>
-  {% endset %}
-  {{ html | render_lit | safe }}
-{% endif %}
-#}
 
 {% endmacro %}


### PR DESCRIPTION
## Context

A couple of small tidy-ups to our Lit components.


## Changes proposed in this pull request

* Remove superfluous `LitElement` imports (as we now import from `RedboxElement` instead)
* Remove the requirement to use the `safe` filter when using `render_lit`


## Guidance to review

Check the changes look sensible and everything works okay


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
