### PR TITLE
Add print button for active chat and add print styles

### DIFF
--- a/django_app/frontend/src/css/general.scss
+++ b/django_app/frontend/src/css/general.scss
@@ -144,3 +144,6 @@ upload-button {
   display: inline;
   padding: 0.125rem;
 }
+
+/* Print styles */
+@import "./print.scss";

--- a/django_app/frontend/src/css/print.scss
+++ b/django_app/frontend/src/css/print.scss
@@ -1,0 +1,21 @@
+@media print {
+
+  /* Hide header and footer */
+  .iai-environment-warning, .iai-top-nav, .iai-footer {
+    display: none;
+  }
+
+  /* Show main column full width */
+  #message-form .govuk-grid-column-one-third {
+    display: none;
+  }
+  .govuk-grid-column-two-thirds {
+    width: 100%;
+  }
+
+  /* Hide other interactive elements */
+  .chat-title__edit-btn, copy-text, feedback-buttons, .exit-feedback, .iai-chat-input {
+    display: none !important;
+  }
+
+}

--- a/django_app/frontend/src/icons/print-svgrepo-com.svg
+++ b/django_app/frontend/src/icons/print-svgrepo-com.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#000000"><rect x="16" y="32" width="32" height="24"/><line x1="24" y1="48" x2="40" y2="48"/><line x1="24" y1="40" x2="40" y2="40"/><polyline points="20 16 20 8 44 8 44 16"/><polyline points="16 40 8 40 8 16 56 16 56 40 48 40"/></svg>

--- a/django_app/frontend/src/js/web-components/chats/chat-history-item.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-history-item.js
@@ -40,13 +40,7 @@ class ChatHistoryItem extends HTMLElement {
       this.toggleButton?.setAttribute("aria-expanded", "false");
       this.#toggleChatTitleEdit(true);
     });
-    if (this.dataset.iscurrentchat === "true") {
-      this.querySelector('[data-action="print"]')?.addEventListener("click", () => {
-        window.print();
-      });
-    } else {
-      this.querySelector('[data-action="print"]').style.display = "none";
-    }
+    this.querySelector('[data-action="print"]')?.addEventListener("click", this.#printChat);
 
     let deleteButton = /** @type {HTMLButtonElement} */ (this.querySelector('[data-action="delete-confirm"]'));
     deleteButton.addEventListener("click", async () => {
@@ -184,6 +178,22 @@ class ChatHistoryItem extends HTMLElement {
       });
       document.dispatchEvent(chatTitleChangeEvent);
     }
+  };
+
+  #printChat = () => {
+    const url = this.querySelector(".rb-chat-history__link").href;
+    const printFrame = document.createElement("iframe");
+    printFrame.addEventListener("load", () => {
+      const closePrint = () => {
+        document.body.removeChild(printFrame);
+      };
+      printFrame.contentWindow.addEventListener("beforeunload", closePrint);
+      printFrame.contentWindow.addEventListener("afterprint", closePrint);
+      printFrame.contentWindow?.print();
+      printFrame.style.display = "none";
+    });
+    printFrame.src = url;
+    document.body.appendChild(printFrame);
   };
 
 }

--- a/django_app/frontend/src/js/web-components/chats/chat-history-item.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-history-item.js
@@ -40,6 +40,13 @@ class ChatHistoryItem extends HTMLElement {
       this.toggleButton?.setAttribute("aria-expanded", "false");
       this.#toggleChatTitleEdit(true);
     });
+    if (this.dataset.iscurrentchat === "true") {
+      this.querySelector('[data-action="print"]')?.addEventListener("click", () => {
+        window.print();
+      });
+    } else {
+      this.querySelector('[data-action="print"]').style.display = "none";
+    }
 
     let deleteButton = /** @type {HTMLButtonElement} */ (this.querySelector('[data-action="delete-confirm"]'));
     deleteButton.addEventListener("click", async () => {

--- a/django_app/frontend/tests-web-components/chat-history.spec.js
+++ b/django_app/frontend/tests-web-components/chat-history.spec.js
@@ -36,6 +36,16 @@ test(`Chat history functionality works as expected`, async ({ page }) => {
   await textInput.press("Enter");
   await expect(chatHistoryItem).toContainText("Renamed chat");
 
+  // The print button only displays for the active chat
+  await page.locator(".rb-chat-history__actions-button").first().click();
+  await page.waitForTimeout(500);
+  await expect(page.locator('button[data-action="print"]').first()).toBeVisible();
+  await page.locator(".rb-chat-history__actions-button").first().click();
+  await page.locator(".rb-chat-history__actions-button").nth(1).click();
+  await page.waitForTimeout(500);
+  await expect(page.locator('button[data-action="print"]').nth(1)).not.toBeVisible();
+  await page.locator(".rb-chat-history__actions-button").nth(1).click();
+
   // A chat can be deleted
   await page.locator(".rb-chat-history__actions-button").first().click();
   await page.locator('button[data-action="delete"]').first().click();

--- a/django_app/frontend/tests-web-components/chat-history.spec.js
+++ b/django_app/frontend/tests-web-components/chat-history.spec.js
@@ -36,16 +36,6 @@ test(`Chat history functionality works as expected`, async ({ page }) => {
   await textInput.press("Enter");
   await expect(chatHistoryItem).toContainText("Renamed chat");
 
-  // The print button only displays for the active chat
-  await page.locator(".rb-chat-history__actions-button").first().click();
-  await page.waitForTimeout(500);
-  await expect(page.locator('button[data-action="print"]').first()).toBeVisible();
-  await page.locator(".rb-chat-history__actions-button").first().click();
-  await page.locator(".rb-chat-history__actions-button").nth(1).click();
-  await page.waitForTimeout(500);
-  await expect(page.locator('button[data-action="print"]').nth(1)).not.toBeVisible();
-  await page.locator(".rb-chat-history__actions-button").nth(1).click();
-
   // A chat can be deleted
   await page.locator(".rb-chat-history__actions-button").first().click();
   await page.locator('button[data-action="delete"]').first().click();

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -197,7 +197,7 @@ CSP_FONT_SRC = (
     "s3.amazonaws.com",
 )
 CSP_STYLE_SRC = ("'self'",)
-CSP_FRAME_ANCESTORS = ("'none'",)
+CSP_FRAME_ANCESTORS = ("'self'",)  # 'self' needed for printing chats
 
 
 CSP_CONNECT_SRC = [

--- a/django_app/redbox_app/templates/macros/chat-history-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-history-macros.html
@@ -49,6 +49,10 @@
                 Rename
                 <span class="govuk-visually-hidden"> chat: {{ chat.name }}</span>
                 </button>
+                <button class="rb-chat-history__level2-button" type="button" data-action="print">
+                    <img width="18" height="18" src="/static/icons/print-svgrepo-com.svg" alt=""/>
+                    Print
+                </button>
             </div>
             <div data-page="2">
                 <div class="rb-chat-history__delete-confirmation">


### PR DESCRIPTION
## Context

We should allow users to easily print chats (for FOI requests)


## Changes proposed in this pull request

* Add a print button in the chat-history menu
<img src="https://github.com/user-attachments/assets/a9a49895-3c24-4ab4-ad1d-08b5391fd3cf" width="150"/>

* Add print-specific styles


## Guidance to review

Find a previous chat. Click the print button. Check the layout looks okay.


## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-972


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
