### PR TITLE
feature/move-route-and-max-tokens-to-django

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -153,7 +153,6 @@ class ChatConsumer(AsyncWebsocketConsumer):
             await self.redbox.run(
                 state,
                 response_tokens_callback=self.handle_text,
-                metadata_tokens_callback=self.handle_metadata,
             )
 
             message = await self.save_ai_message(

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -153,7 +153,6 @@ class ChatConsumer(AsyncWebsocketConsumer):
             await self.redbox.run(
                 state,
                 response_tokens_callback=self.handle_text,
-                route_name_callback=self.handle_route,
                 metadata_tokens_callback=self.handle_metadata,
             )
 
@@ -251,10 +250,6 @@ class ChatConsumer(AsyncWebsocketConsumer):
     async def handle_text(self, response: str) -> str:
         await self.send_to_client("text", response)
         self.full_reply.append(response)
-
-    async def handle_route(self, response: str) -> str:
-        await self.send_to_client("route", response)
-        self.route = response
 
     async def handle_metadata(self, response: dict):
         self.metadata = metadata_reducer(self.metadata, RequestMetadata.model_validate(response))

--- a/django_app/tests/conftest.py
+++ b/django_app/tests/conftest.py
@@ -285,6 +285,7 @@ def several_files(alice: User, number_to_create: int = 4) -> Sequence[File]:
                 user=alice,
                 original_file=SimpleUploadedFile(filename, b"Lorem Ipsum."),
                 status=File.Status.complete,
+                metadata={"token_count": i * 100},
             )
         )
     return files

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -76,11 +76,6 @@ async def test_chat_consumer_with_new_session(alice: User, mocked_connect: Conne
     assert await get_chat_message_text(alice, ChatMessage.Role.user) == ["Hello Hal."]
     assert await get_chat_message_text(alice, ChatMessage.Role.ai) == ["Good afternoon, Mr. Amor."]
 
-    assert await get_token_use_model(ChatMessageTokenUse.UseType.INPUT) == "gpt-4o"
-    assert await get_token_use_model(ChatMessageTokenUse.UseType.OUTPUT) == "gpt-4o"
-    assert await get_token_use_count(ChatMessageTokenUse.UseType.INPUT) == 123
-    assert await get_token_use_count(ChatMessageTokenUse.UseType.OUTPUT) == 1000
-
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio()
@@ -200,11 +195,6 @@ async def test_chat_consumer_agentic(alice: User, mocked_connect_agentic_search:
 
     assert await get_chat_message_text(alice, ChatMessage.Role.user) == ["Hello Hal."]
     assert await get_chat_message_text(alice, ChatMessage.Role.ai) == ["Good afternoon, Mr. Amor."]
-
-    assert await get_token_use_model(ChatMessageTokenUse.UseType.INPUT) == "gpt-4o"
-    assert await get_token_use_model(ChatMessageTokenUse.UseType.OUTPUT) == "gpt-4o"
-    assert await get_token_use_count(ChatMessageTokenUse.UseType.INPUT) == 123
-    assert await get_token_use_count(ChatMessageTokenUse.UseType.OUTPUT) == 1000
 
 
 @database_sync_to_async

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -61,7 +61,7 @@ async def test_chat_consumer_with_new_session(alice: User, mocked_connect: Conne
         response2 = await communicator.receive_json_from(timeout=5)
         response3 = await communicator.receive_json_from(timeout=5)
         response4 = await communicator.receive_json_from(timeout=5)
-        response5 = await communicator.receive_json_from(timeout=5)
+        # response5 = await communicator.receive_json_from(timeout=5)
 
         # Then
         assert response1["type"] == "session-id"
@@ -69,15 +69,12 @@ async def test_chat_consumer_with_new_session(alice: User, mocked_connect: Conne
         assert response2["data"] == "Good afternoon, "
         assert response3["type"] == "text"
         assert response3["data"] == "Mr. Amor."
-        assert response4["type"] == "route"
-        assert response4["data"] == "gratitude"
-        assert response5["type"] == "end"
+        assert response4["type"] == "end"
         # Close
         await communicator.disconnect()
 
     assert await get_chat_message_text(alice, ChatMessage.Role.user) == ["Hello Hal."]
     assert await get_chat_message_text(alice, ChatMessage.Role.ai) == ["Good afternoon, Mr. Amor."]
-    assert await get_chat_message_route(alice, ChatMessage.Role.ai) == ["gratitude"]
 
     assert await get_token_use_model(ChatMessageTokenUse.UseType.INPUT) == "gpt-4o"
     assert await get_token_use_model(ChatMessageTokenUse.UseType.OUTPUT) == "gpt-4o"
@@ -102,7 +99,7 @@ async def test_chat_consumer_staff_user(staff_user: User, mocked_connect: Connec
         response2 = await communicator.receive_json_from(timeout=5)
         response3 = await communicator.receive_json_from(timeout=5)
         response4 = await communicator.receive_json_from(timeout=5)
-        _response5 = await communicator.receive_json_from(timeout=5)
+        # _response5 = await communicator.receive_json_from(timeout=5)
 
         # Then
         assert response1["type"] == "session-id"
@@ -110,12 +107,9 @@ async def test_chat_consumer_staff_user(staff_user: User, mocked_connect: Connec
         assert response2["data"] == "Good afternoon, "
         assert response3["type"] == "text"
         assert response3["data"] == "Mr. Amor."
-        assert response4["type"] == "route"
-        assert response4["data"] == "gratitude"
+        assert response4["type"] == "end"
         # Close
         await communicator.disconnect()
-
-    assert await get_chat_message_route(staff_user, ChatMessage.Role.ai) == ["gratitude"]
 
 
 @pytest.mark.django_db(transaction=True)
@@ -161,7 +155,6 @@ async def test_chat_consumer_with_naughty_question(alice: User, mocked_connect: 
         response2 = await communicator.receive_json_from(timeout=5)
         response3 = await communicator.receive_json_from(timeout=5)
         response4 = await communicator.receive_json_from(timeout=5)
-        response5 = await communicator.receive_json_from(timeout=5)
 
         # Then
         assert response1["type"] == "session-id"
@@ -169,15 +162,12 @@ async def test_chat_consumer_with_naughty_question(alice: User, mocked_connect: 
         assert response2["data"] == "Good afternoon, "
         assert response3["type"] == "text"
         assert response3["data"] == "Mr. Amor."
-        assert response4["type"] == "route"
-        assert response4["data"] == "gratitude"
-        assert response5["type"] == "end"
+        assert response4["type"] == "end"
         # Close
         await communicator.disconnect()
 
     assert await get_chat_message_text(alice, ChatMessage.Role.user) == ["Hello Hal. \ufffd"]
     assert await get_chat_message_text(alice, ChatMessage.Role.ai) == ["Good afternoon, Mr. Amor."]
-    assert await get_chat_message_route(alice, ChatMessage.Role.ai) == ["gratitude"]
 
 
 @pytest.mark.django_db(transaction=True)
@@ -197,7 +187,6 @@ async def test_chat_consumer_agentic(alice: User, mocked_connect_agentic_search:
         response2 = await communicator.receive_json_from(timeout=5)
         response3 = await communicator.receive_json_from(timeout=5)
         response4 = await communicator.receive_json_from(timeout=5)
-        response5 = await communicator.receive_json_from(timeout=5)
 
         # Then
         assert response1["type"] == "session-id"
@@ -205,9 +194,7 @@ async def test_chat_consumer_agentic(alice: User, mocked_connect_agentic_search:
         assert response2["data"] == "Good afternoon, "
         assert response3["type"] == "text"
         assert response3["data"] == "Mr. Amor."
-        assert response4["type"] == "route"
-        assert response4["data"] == "search/agentic"
-        assert response5["type"] == "end"
+        assert response4["type"] == "end"
         # Close
         await communicator.disconnect()
 


### PR DESCRIPTION
## Context

In this PR I move the set-route and max-tokens-exceeded logic into django [fabd607](https://github.com/i-dot-ai/redbox/pull/1299/commits/fabd607a30d12c4df1158aacbaffb54300d9a3c0) this allows us to delete a lot of the rest of the code (subsequent commits)

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
