### PR TITLE
feature/block un processed files

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -103,6 +103,10 @@ class ChatConsumer(AsyncWebsocketConsumer):
             session.name = user_message_text[: settings.CHAT_TITLE_LENGTH]
             await session.asave()
 
+        if await File.objects.filter(id__in=selected_file_uuids, status=File.Status.processing).aexists():
+            await self.send_to_client("error", "you have files waiting to be processed")
+            return
+
         # save user message
         permitted_files = File.objects.filter(user=user, status=File.Status.complete)
         selected_files = permitted_files.filter(id__in=selected_file_uuids)
@@ -122,7 +126,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
         ai_settings = await self.get_ai_settings(session)
 
-        document_token_count = sum(file.metadata["token_count"] for file in selected_files)
+        document_token_count = sum(file.metadata.get("token_count", 0) for file in selected_files)
         message_history_token_count = sum(message.token_count for message in message_history)
 
         if document_token_count + message_history_token_count > ai_settings.context_window_size:

--- a/django_app/tests/conftest.py
+++ b/django_app/tests/conftest.py
@@ -298,3 +298,20 @@ def chat_message_with_rating(chat_message: ChatMessage) -> ChatMessage:
     chat_message.rating_chips = ["speed", "accuracy", "blasphemy"]
     chat_message.save()
     return chat_message
+
+
+@pytest.fixture()
+def mix_of_file_statues(alice: User, chat) -> Sequence[File]:
+    files = []
+    for status in File.Status.complete, File.Status.processing:
+        filename = f"original_file_{status}.txt"
+        files.append(
+            File.objects.create(
+                user=alice,
+                original_file=SimpleUploadedFile(filename, b"Lorem Ipsum."),
+                status=status,
+                metadata={"token_count": 100},
+                chat=chat,
+            )
+        )
+    return files


### PR DESCRIPTION
## Context

As a user I want to be blocked from querying unprocessed files so that I dont accidentally query them thinking that they are ready

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-860

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
