### PR TITLE
feature/restored file-admin

### DIFF
--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -202,10 +202,18 @@ class ChatAdmin(ExportMixin, admin.ModelAdmin):
             },
         ),
     ]
-    inlines = [ChatMessageInline]
+    inlines = [ChatMessageInline, FileInline]
     list_display = ["name", "user", "created_at"]
     list_filter = ["user"]
     date_hierarchy = "created_at"
+    search_fields = ["user__email"]
+
+
+class FileAdmin(ExportMixin, admin.ModelAdmin):
+    list_display = ["file_name", "user", "status", "created_at", "last_referenced"]
+    list_filter = ["user", "status"]
+    date_hierarchy = "created_at"
+    actions = ["reupload"]
     search_fields = ["user__email"]
 
 
@@ -217,4 +225,5 @@ admin.site.register(User, UserAdmin)
 admin.site.register(models.Chat, ChatAdmin)
 admin.site.register(models.AISettings)
 admin.site.register(models.ChatLLMBackend, ChatLLMBackendAdmin)
+admin.site.register(models.File, FileAdmin)
 admin.site.register_view("report/", view=reporting_dashboard, name="Site report")


### PR DESCRIPTION
## Context

As an Engineer I want:
* to restore the file admin whilst we still files no associated with any chat (temporarily)
* a file inline so that I can see files associated with a `chat`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
