### PR TITLE
Added user_id back into the elastic metrics logging

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -745,6 +745,7 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
             "@timestamp": self.created_at.isoformat(),
             "id": str(self.id),
             "chat_id": str(self.chat.id),
+            "user_id": str(self.chat.user.id),
             "department": self.chat.user.email.split("@")[-1],
             "user_business_unit": self.chat.user.business_unit,
             "user_grade": self.chat.user.grade,


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We accidentally removed user_id from the elastic (metrics) logging.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

We're now adding it back in.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Once it's deployed, then go to elastic console and check latest messages contain this field. There's no impact on the production app only on the logging.

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
