### PR TITLE
feature/catch markitdown error

### DIFF
--- a/django_app/redbox_app/worker.py
+++ b/django_app/redbox_app/worker.py
@@ -1,7 +1,7 @@
 import logging
 from uuid import UUID
 
-from markitdown import MarkItDown
+from markitdown import MarkItDown, UnsupportedFormatException
 
 from redbox.chains.components import get_tokeniser
 from redbox_app.redbox_core.utils import sanitise_string
@@ -23,8 +23,7 @@ def ingest(file_id: UUID) -> None:
         file.text = sanitise_string(markdown.text_content)
         file.token_count = len(tokeniser.encode(markdown.text_content))
         file.status = File.Status.complete
-        file.save()
-    except Exception as error:  # noqa: BLE001
+    except (Exception, UnsupportedFormatException) as error:  # noqa: BLE001
         file.status = File.Status.errored
         file.ingest_error = str(error)
-        file.save()
+    file.save()

--- a/django_app/redbox_app/worker.py
+++ b/django_app/redbox_app/worker.py
@@ -23,7 +23,7 @@ def ingest(file_id: UUID) -> None:
         file.text = sanitise_string(markdown.text_content)
         file.token_count = len(tokeniser.encode(markdown.text_content))
         file.status = File.Status.complete
-    except (Exception, UnsupportedFormatException) as error:  # noqa: BLE001
+    except (Exception, UnsupportedFormatException) as error:
         file.status = File.Status.errored
         file.ingest_error = str(error)
     file.save()


### PR DESCRIPTION
## Context

When MarkItDown raises an `UnsupportedFormatException` it isnt caught by `Exception` as it inherits from `BaseException`, now we catch it explicitly

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
