### PR TITLE
Remove reference to version number on Support page

### DIFF
--- a/django_app/redbox_app/templates/support.html
+++ b/django_app/redbox_app/templates/support.html
@@ -53,7 +53,7 @@
     <p class="govuk-body">If the website is not loading, please close the browser tab and try again later.</p>
 
     <h2 class="govuk-heading-m">Contact us</h2>
-    <p class="govuk-body">If you've read the information above but haven't been able to find a solution to your problem, please email us at <a href="mailto:{{contact_email}}" class="govuk-link">{{contact_email}}</a> including as much information as possible, including the current version number, which is {{ version }}.</p>
+    <p class="govuk-body">If you've read the information above but haven't been able to find a solution to your problem, please email us at <a href="mailto:{{contact_email}}" class="govuk-link">{{contact_email}}</a> including as much information as possible.</p>
 
   </div>
 </div>

--- a/django_app/tests/test_info_views.py
+++ b/django_app/tests/test_info_views.py
@@ -1,12 +1,8 @@
 from bs4 import BeautifulSoup
-from django.conf import settings
 from django.test import Client
 
 
-def test_support_view_contains_contact_emai_and_version_number(client: Client):
-    # Given
-    version = settings.REDBOX_VERSION
-
+def test_support_view_contains_contact_email(client: Client):
     # When
     response = client.get("/support/")
 
@@ -16,4 +12,3 @@ def test_support_view_contains_contact_emai_and_version_number(client: Client):
         a.get("href", "").removeprefix("mailto:") for a in soup.find_all("a") if a.get("href", "").startswith("mailto:")
     ]
     assert mailto_links
-    assert version in str(response.content)


### PR DESCRIPTION
## Context

We no longer use version numbers, so we should remove references to it.


## Changes proposed in this pull request

* Update last line of Support page
* Remove version-check from tests


## Guidance to review

Check it reads okay


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
