### PR TITLE
Reinstate experience cards styling

### DIFF
--- a/django_app/frontend/src/css/general.scss
+++ b/django_app/frontend/src/css/general.scss
@@ -94,10 +94,10 @@ body {
 }
 @import "../../node_modules/i.ai-design-system/dist/styles.scss";
 
+@import "./profile.scss";
 
 /* Chats Page - to come after i.AI Design System */
 @import "./chats/chats.scss";
-
 
 /* Print styles */
 @import "./print.scss";

--- a/django_app/frontend/src/css/profile.scss
+++ b/django_app/frontend/src/css/profile.scss
@@ -1,0 +1,83 @@
+/* Experience cards for chat-page overlay and demographics page */
+
+.experience-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: flex-start;
+}
+.experience-cards .govuk-radios__item {
+  margin-bottom: 0;
+  width: 11rem;
+}
+.experience-cards input {
+  opacity: 0;
+  position: absolute;
+}
+.experience-cards label {
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: block;
+  font-size: 1rem;
+  height: 100%;
+  line-height: 1.3;
+  padding: 1rem;
+  position: relative;
+  max-width: none;
+}
+.experience-cards input:focus-visible + label {
+  outline: 3px solid #fd0;
+}
+.experience-cards label::before {
+  display: flex;
+  height: 5.75rem;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  opacity: 0.5;
+  transform: scale(0.85);
+  transition: all 0.5s;
+  width: 100%;
+}
+.experience-cards input:checked + label {
+  border-color: var(--iai-colour-text-primary);
+}
+.experience-cards label:hover::before,
+.experience-cards input:checked + label::before {
+  opacity: 1;
+  transform: scale(1);
+}
+.experience-cards input:checked + label:hover::before {
+  border-width: 0;
+}
+.experience-cards .govuk-radios__item:nth-child(1) label::before {
+  content: url("/static/icons/ai-experience-cards/Curious.svg");
+}
+.experience-cards .govuk-radios__item:nth-child(2) label::before {
+  content: url("/static/icons/ai-experience-cards/Cautious.svg");
+}
+.experience-cards .govuk-radios__item:nth-child(3) label::before {
+  content: url("/static/icons/ai-experience-cards/Enthusiastic.svg");
+  margin-bottom: 2rem;
+  margin-top: -0.75rem;
+}
+.experience-cards .govuk-radios__item:nth-child(4) label::before {
+  content: url("/static/icons/ai-experience-cards/Experienced.svg");
+}
+.experience-cards .govuk-radios__item:nth-child(5) label::before {
+  content: url("/static/icons/ai-experience-cards/Alchemist.svg");
+}
+.experience-cards input:checked + label::after {
+  content: url("/static/icons/ai-experience-cards/Tick.svg");
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+}
+.experience-cards .govuk-hint {
+  color: var(--iai-colour-text-primary);
+  font-size: 0.75rem;
+  margin-bottom: 0;
+  margin-top: 0.5rem;
+  padding: 0;
+}


### PR DESCRIPTION
## Context

The styling had disappeared due to a previous over-zealous code clear-out on my part.


## Changes proposed in this pull request

Reinstate CSS so the AI experience cards look like this on the profile page:

![image](https://github.com/user-attachments/assets/60dc9088-f4c7-4ed1-b08f-369a1e3dd924)


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
