### PR TITLE
Display a message when there are no chats in chat-history

### DIFF
--- a/django_app/frontend/src/css/chats/chat-history.scss
+++ b/django_app/frontend/src/css/chats/chat-history.scss
@@ -2,6 +2,13 @@
   background-color: white;
   position: relative;
 }
+.rb-chat-history__no-chats {
+  margin-bottom: 0.75rem;
+  margin-top: 0.5rem;
+}
+.rb-chat-history:has(li) .rb-chat-history__no-chats {
+  display: none;
+}
 .iai-panel__scrollable--chat-history {
   margin-top: -0.75rem;
   max-height: calc(100vh - 20rem);

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -24,8 +24,10 @@
           New chat
         </a>
 
-        <div class="iai-panel govuk-!-margin-top-5 govuk-!-padding-top-3">
+        <div class="rb-chat-history iai-panel govuk-!-margin-top-5 govuk-!-padding-top-3">
           <h2 class="govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-0 rb-chat-history__title">Recent chats</h2>
+          <p class="rb-chat-history__no-chats govuk-body-s">You have no saved chats</p>
+
           <div class="iai-panel__scrollable iai-panel__scrollable--chat-history govuk-!-padding-right-3">
 
             <chat-history>


### PR DESCRIPTION
## Changes proposed in this pull request

State when there are no chats in the chat-history, and make it look better.

<img src="https://github.com/user-attachments/assets/fe93bfa2-2234-429b-86a7-13158564af4e" width="250"/>


## Guidance to review

* Clear chats, check it looks okay
* Check the message disappears once a chat is created


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
