### PR TITLE
Ensure chat titles are unique

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-history.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-history.js
@@ -64,7 +64,7 @@ class ChatHistory extends HTMLElement {
     this.#createTodayHeading();
     let item = this.querySelector(`[data-chatid="${chatId}"]`)?.closest("li");
     if (!item) {
-      item = this.#createItem(chatId, title.substring(0, 30));
+      item = this.#createItem(chatId, title);
     }
     this.querySelector("ul")?.prepend(item);
   }


### PR DESCRIPTION
## Context

We need to ensure chat titles are unique (for a user). This is to help with accessibility - if there are multiple links with the same name (but taking users to different places) this can cause confusion.


## Changes proposed in this pull request

Ensure chat titles are unique  by appending " (x)" to the title (where x is the lowest unique integer)


## Guidance to review

* Create a new chat and send a message saying "Testing"
* Do the same again
* Check that one is called "Testing" and the other is called "Testing (1)"


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
