### PR TITLE
Show detailed error message if token limit exceeded

### DIFF
--- a/django_app/frontend/src/css/chats/chats.scss
+++ b/django_app/frontend/src/css/chats/chats.scss
@@ -234,6 +234,12 @@ chat-message {
   background-color: $redbox-red;
 }
 
+.rb-token-sizes li span:nth-child(1) {
+  display: inline-block;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
 @import "./chat-input.scss";
 
 @import "./documents.scss";

--- a/django_app/frontend/src/js/web-components/documents/document-container.mjs
+++ b/django_app/frontend/src/js/web-components/documents/document-container.mjs
@@ -18,7 +18,7 @@ export class DocumentContainer extends RedboxElement {
         <ul>
           ${this.docs?.map(
             (doc) => html`
-              <li class="rb-uploaded-docs__item iai-chat-bubble">
+              <li class="rb-uploaded-docs__item iai-chat-bubble" data-tokens=${doc.tokens} data-name=${doc.file_name}>
                 <img src="/static/icons/doc.svg" alt="" loading="lazy"/>
                 ${doc.file_name}
               </li>

--- a/django_app/frontend/src/js/web-components/documents/file-status.mjs
+++ b/django_app/frontend/src/js/web-components/documents/file-status.mjs
@@ -14,12 +14,14 @@ class FileStatus extends RedboxElement {
     id: { type: String, attribute: "data-id" },
     status: { type: String, state: true },
     positionInQueue: { type: Number, state: true },
-    name: { type: String, attribute: "data-name" }
+    name: { type: String, attribute: "data-name" },
+    tokens: { type: Number, state: true }
   };
 
   connectedCallback() {
     super.connectedCallback();
     this.status = this.textContent || "Uploading";
+    this.tokens = 0;
     this.#checkStatus();
   }
 
@@ -51,7 +53,7 @@ class FileStatus extends RedboxElement {
 
     return html`
       ${icon}
-      <span data-status=${statusAttr} aria-live="assertive" aria-atomic="true">
+      <span data-status=${statusAttr} data-tokens=${this.tokens} data-name=${this.name} aria-live="assertive" aria-atomic="true">
         ${statusText}
         <span class="govuk-visually-hidden">${this.name}</span>
       </span>
@@ -96,6 +98,7 @@ class FileStatus extends RedboxElement {
     const responseObj = await response.json();
     this.status = responseObj.status;
     this.positionInQueue = responseObj.position_in_queue;
+    this.tokens = responseObj.tokens || 0;
 
     if (responseObj.status.toLowerCase() === "error") {
       this.#sendErrorEvent();

--- a/django_app/frontend/src/js/web-components/documents/upload-container.mjs
+++ b/django_app/frontend/src/js/web-components/documents/upload-container.mjs
@@ -14,6 +14,12 @@ export class UploadContainer extends RedboxElement {
       /** @type {NodeListOf<import("./document-container.mjs").DocumentContainer>} */
       const documentContainers = document.querySelectorAll("document-container");
       const lastDocumentContainer = documentContainers[documentContainers.length - 1];
+        // add tokens to the docs array
+        /** @type {NodeListOf<HTMLElement> | undefined} */ (this.querySelectorAll("[data-tokens"))?.forEach((element, index) => {
+        if (this.docs) {
+          this.docs[index].tokens = parseInt(element.dataset.tokens || "0");
+        }
+      });
       lastDocumentContainer.addDocuments(this.docs);
       this.docs = [];
     });

--- a/django_app/frontend/tests-web-components/documents.spec.js
+++ b/django_app/frontend/tests-web-components/documents.spec.js
@@ -17,7 +17,10 @@ test(`A document can be uploaded and removed before sending`, async ({ page }) =
 });
 
 
-test(`A document can be sent`, async ({ page }) => {
+test(`A document can be sent (and token sizes are checked)`, async ({ page }) => {
+
+  const fileTokenSize = "30";
+
   await signIn(page);
 
   await expect(page.locator("file-status")).toHaveCount(0);
@@ -27,11 +30,14 @@ test(`A document can be sent`, async ({ page }) => {
   // sending the message before the document is uploaded should fail
   await sendMessage(page);
   await expect(page.locator("chat-message")).toContainText("You have files waiting to be processed. Please wait for these to complete and then send the message again.");
-  
+
   // sending the message after the document is uploaded should succeed
+  await expect(page.locator("file-status [data-tokens]")).toHaveAttribute("data-tokens", fileTokenSize);
   await expect(page.locator("file-status")).toHaveText("Complete test-upload.html");
   await sendMessage(page);
   await expect(page.locator(".rb-uploaded-docs__item")).toContainText("test-upload.html");
+  await expect(page.locator(".rb-uploaded-docs__item")).toHaveAttribute("data-tokens", fileTokenSize);
+
   await expect(page.locator("file-status")).toHaveCount(0);
 
 });

--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -92,7 +92,15 @@ def filter_docs(docs, messages, message_index):
     active_docs = [doc for doc in docs if doc.get_status_text() != "Deleted"]
     filtered_docs = [doc for doc in active_docs if start_timestamp < doc.created_at < end_timestamp]
     return json.dumps(
-        [{"id": str(doc.id), "file_name": doc.file_name, "file_status": doc.get_status_text()} for doc in filtered_docs]
+        [
+            {
+                "id": str(doc.id),
+                "file_name": doc.file_name,
+                "file_status": doc.get_status_text(),
+                "tokens": doc.token_count,
+            }
+            for doc in filtered_docs
+        ]
     )
 
 

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -72,6 +72,7 @@ class ChatsView(View):
                 }
                 for chat_llm_backend in ChatLLMBackend.objects.filter(enabled=True)
             ],
+            "max_tokens": settings.LLM_MAX_TOKENS,
         }
 
         return render(

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -72,7 +72,7 @@ class ChatsView(View):
                 }
                 for chat_llm_backend in ChatLLMBackend.objects.filter(enabled=True)
             ],
-            "max_tokens": settings.LLM_MAX_TOKENS,
+            "max_tokens": chat_backend.context_window_size,
         }
 
         return render(

--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -133,4 +133,6 @@ def file_status_api_view(request: HttpRequest) -> JsonResponse:
     except File.DoesNotExist as ex:
         logger.exception("File object information not found in django - file does not exist %s.", file_id, exc_info=ex)
         return JsonResponse({"status": File.Status.errored.label})
-    return JsonResponse({"status": file.get_status_text(), "position_in_queue": file.position_in_queue()})
+    return JsonResponse(
+        {"status": file.get_status_text(), "position_in_queue": file.position_in_queue(), "tokens": file.token_count}
+    )

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -30,8 +30,6 @@ ENVIRONMENT = Environment[env.str("ENVIRONMENT").upper()]
 WEBSOCKET_SCHEME = "ws" if ENVIRONMENT.is_test else "wss"
 LOGIN_METHOD = env.str("LOGIN_METHOD", None)
 
-LLM_MAX_TOKENS = env.str("LLM_MAX_TOKENS", 1024)
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG")
 

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -30,6 +30,8 @@ ENVIRONMENT = Environment[env.str("ENVIRONMENT").upper()]
 WEBSOCKET_SCHEME = "ws" if ENVIRONMENT.is_test else "wss"
 LOGIN_METHOD = env.str("LOGIN_METHOD", None)
 
+LLM_MAX_TOKENS = env.str("LLM_MAX_TOKENS", 1024)
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG")
 

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -75,7 +75,7 @@
           {% endif %}
         </chat-title>
 
-        <chat-controller class="iai-chat-container" data-stream-url="{{ streaming.endpoint }}" data-session-id="{{ chat_id or '' }}">
+        <chat-controller class="iai-chat-container" data-stream-url="{{ streaming.endpoint }}" data-session-id="{{ chat_id or '' }}" data-max-tokens="{{ max_tokens }}">
 
           <div class="rb-chat-message__container js-message-container">
 


### PR DESCRIPTION
## Context

As a user I need to be informed if the docs I attach are above the token limit, and to understand what I can do about it.


## Changes proposed in this pull request

* Frontend to get the token sizes for each file
* When a user sends the message, the token sizes are checked, and sending is blocked if above the limit
* Show a meaningful error message, showing individual file token sizes
* Update tests

<img src="https://github.com/user-attachments/assets/0f9ee568-9c7a-4912-b5ee-afb6977785d3" width="400"/>


## Guidance to review

* Set a low `MAX_TOKEN_SIZE` env value, and upload a large doc
* Check the error message reads okay
* Check it sends okay once you've increased `MAX_TOKEN_SIZE` again


## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-1012


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
