### PR TITLE
Ensure blur event doesn't override click event

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/model-selector.mjs
+++ b/django_app/frontend/src/js/web-components/chats/model-selector.mjs
@@ -117,7 +117,7 @@ export class ModelSelector extends RedboxElement {
   #blur() {
     window.setTimeout(() => {
       this.expanded = false;
-    }, 100);
+    }, 200);
   }
 
 }


### PR DESCRIPTION
## Context

I've found there's a very specific place to click on the model selector where the model doesn't change. On delving into this deeper it seems that the blur event (that's needed if a user moves away from the control) was firing before the click event.


## Changes proposed in this pull request

Delay the blur event further so that the click event has time to fire.


## Guidance to review

Check the model selector works okay


## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
