### PR TITLE
bugfix/send-messages-in-order

### DIFF
--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -170,9 +170,9 @@ class FileInline(admin.StackedInline):
 
 class ChatMessageInline(admin.StackedInline):
     model = models.ChatMessage
-    ordering = "created_at"
-    fields = ["text", "role", "route", "rating"]
-    readonly_fields = ["text", "role", "route", "rating"]
+    ordering = ("created_at",)
+    fields = ["created_at", "text", "role", "route", "rating"]
+    readonly_fields = ["created_at", "text", "role", "route", "rating"]
     extra = 0
 
 

--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -170,9 +170,9 @@ class FileInline(admin.StackedInline):
 
 class ChatMessageInline(admin.StackedInline):
     model = models.ChatMessage
-    ordering = "-created_at"
-    fields = ["created_at", "text", "role", "route", "rating"]
-    readonly_fields = ["created_at", "text", "role", "route", "rating"]
+    ordering = "created_at"
+    fields = ["text", "role", "route", "rating"]
+    readonly_fields = ["text", "role", "route", "rating"]
     extra = 0
 
 
@@ -181,7 +181,7 @@ class ChatAdmin(ExportMixin, admin.ModelAdmin):
         (
             None,
             {
-                "fields": ["name", "user"],
+                "fields": ["name", "user", "created_at"],
             },
         ),
         (

--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -170,11 +170,10 @@ class FileInline(admin.StackedInline):
 
 class ChatMessageInline(admin.StackedInline):
     model = models.ChatMessage
-    ordering = ("modified_at",)
-    fields = ["text", "role", "route", "rating"]
-    readonly_fields = ["text", "role", "route", "rating"]
+    ordering = "-created_at"
+    fields = ["created_at", "text", "role", "route", "rating"]
+    readonly_fields = ["created_at", "text", "role", "route", "rating"]
     extra = 0
-    show_change_link = True  # allows users to click through to look at Citations
 
 
 class ChatAdmin(ExportMixin, admin.ModelAdmin):

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -474,7 +474,7 @@ class Chat(UUIDPrimaryKeyBase, TimeStampedModel):
 
         return redbox.models.chain.RedboxState(
             documents=[Document(str(f.text), metadata={"uri": f.original_file.name}) for f in self.file_set.all()],
-            messages=[message.to_langchain() for message in self.chatmessage_set.order_by("-created_at")],
+            messages=[message.to_langchain() for message in self.chatmessage_set.order_by("created_at")],
             chat_backend=chat_backend,
         )
 

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -474,7 +474,7 @@ class Chat(UUIDPrimaryKeyBase, TimeStampedModel):
 
         return redbox.models.chain.RedboxState(
             documents=[Document(str(f.text), metadata={"uri": f.original_file.name}) for f in self.file_set.all()],
-            messages=[message.to_langchain() for message in self.chatmessage_set.all()],
+            messages=[message.to_langchain() for message in self.chatmessage_set.order_by("-created_at")],
             chat_backend=chat_backend,
         )
 


### PR DESCRIPTION
## Context

As a user I want the messages to be sent to the LLM in the correct order so that:
* the context makes sense
* my last message is the one that is answered

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
