### PR TITLE
Update max_tokens per model

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-controller.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-controller.js
@@ -29,7 +29,7 @@ class ChatController extends HTMLElement {
       }
 
       // Prevent message sending if uploaded files are over the max token size
-      const maxTokens = parseInt(this.dataset.maxTokens || "0");
+      const maxTokens = parseInt(/** @type {HTMLInputElement} */(document.querySelector("#max-tokens")).value || "0");
       let tokenCount = 0;
       let fileList = "";
       /** @type {NodeListOf<HTMLElement>} */

--- a/django_app/frontend/src/js/web-components/chats/model-selector.mjs
+++ b/django_app/frontend/src/js/web-components/chats/model-selector.mjs
@@ -45,6 +45,7 @@ export class ModelSelector extends RedboxElement {
           `)}
         </div>
         <input type="hidden" id="llm-selector" name="llm" value=${this.options[this.selectedOption].id}/>
+        <input type="hidden" id="max-tokens" value=${this.options[this.selectedOption].max_tokens}/>
       `;
     }
     return html`

--- a/django_app/frontend/tests-web-components/model-selector.spec.js
+++ b/django_app/frontend/tests-web-components/model-selector.spec.js
@@ -9,10 +9,16 @@ test(`A different model can be selected`, async ({ page }) => {
   // The component is rendered and displaying the currently selected model
   await expect(select).toContainText("gpt-4o");
 
+  // max-tokens is set correctly
+  expect(await page.locator("#max-tokens").inputValue()).toBe("128000");
+
   // A new value can be selected
   await select.click();
   await page.locator("#model-option-2").click();
   await expect(select).toContainText("Claude");
+
+  // max-tokens has updated
+  expect(await page.locator("#max-tokens").inputValue()).not.toBe("128000");
 
   // The new value is also set as the active option (this is different to the selected option)
   await select.click();

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -69,10 +69,10 @@ class ChatsView(View):
                     "selected": chat_llm_backend == chat_backend,
                     "id": chat_llm_backend.id,
                     "description": chat_llm_backend.description,
+                    "max_tokens": chat_llm_backend.context_window_size,
                 }
                 for chat_llm_backend in ChatLLMBackend.objects.filter(enabled=True)
             ],
-            "max_tokens": chat_backend.context_window_size,
         }
 
         return render(

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -75,7 +75,7 @@
           {% endif %}
         </chat-title>
 
-        <chat-controller class="iai-chat-container" data-stream-url="{{ streaming.endpoint }}" data-session-id="{{ chat_id or '' }}" data-max-tokens="{{ max_tokens }}">
+        <chat-controller class="iai-chat-container" data-stream-url="{{ streaming.endpoint }}" data-session-id="{{ chat_id or '' }}">
 
           <div class="rb-chat-message__container js-message-container">
 


### PR DESCRIPTION
## Context

At the moment `max_tokens` is only being passed in on page load. This fails to allow for models which have a higher limit.


## Changes proposed in this pull request

Update `max_tokens` per model


## Guidance to review

Change models and check the token limit changes.


## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
