### PR TITLE
Feature/check file exists before ingesting it

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -619,7 +619,7 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
         )
 
     def position_in_queue(self) -> int:
-        if not self.task:
+        if not self.task_id:
             return -1
         return OrmQ.objects.filter(lock__lt=self.task.lock).count()
 

--- a/django_app/redbox_app/worker.py
+++ b/django_app/redbox_app/worker.py
@@ -14,7 +14,11 @@ def ingest(file_id: UUID) -> None:
     # These models need to be loaded at runtime otherwise they can be loaded before they exist
     from redbox_app.redbox_core.models import File
 
-    file = File.objects.get(id=file_id)
+    try:
+        file = File.objects.get(id=file_id)
+    except File.DoesNotExist:
+        logging.info("file_id=%s no longer exists, has the user deleted it?", file_id)
+        return
 
     logging.info("Ingesting file: %s", file)
 


### PR DESCRIPTION
## Context

As an Engineer I want to catch the case where the `File`/`Task` relationship is broken because either:
* the `Task` is complete and has been deleted
* the `File` has been deleted by the user before the ingest process has completed

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-762

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
