### PR TITLE
Ensure the correct Message ID is passed to feedback-buttons

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -10,7 +10,12 @@ export class ChatMessage extends HTMLElement {
   }
 
   connectedCallback() {
-    this.uuid = crypto.randomUUID();
+    
+    /**
+     * A random UUID for UI elements - this is not the Django message ID
+     */
+    const uuid = crypto.randomUUID();
+    
     this.innerHTML = `
       <div class="iai-chat-bubble govuk-body {{ classes }}" data-role="${
         this.dataset.role
@@ -145,7 +150,7 @@ export class ChatMessage extends HTMLElement {
         chatControllerRef.dataset.sessionId = response.data;
       } else if (response.type === "end") {
         let chatMessageFooter = document.createElement("chat-message-footer");
-        chatMessageFooter.dataset.id = this.uuid;
+        chatMessageFooter.dataset.id = response.data.message_id;
         this.parentElement?.appendChild(chatMessageFooter);
 
         const chatResponseEndEvent = new CustomEvent("chat-response-end", {

--- a/django_app/frontend/tests-web-components/feedback-buttons.spec.js
+++ b/django_app/frontend/tests-web-components/feedback-buttons.spec.js
@@ -12,4 +12,10 @@ test(`Individual message feedback can be entered`, async ({ page }) => {
   await page.locator('[data-rating="3"]').click();
   await expect(page.getByText("Thanks for the feedback")).toBeVisible();
 
+  // The message ID is passed to the component (both for CSR and SSR)
+  const messageIdCSR = await page.locator('feedback-buttons').getAttribute("data-id");
+  await page.reload();
+  const messageIdSSR = await page.locator('feedback-buttons').getAttribute("data-id");
+  expect(messageIdCSR).toEqual(messageIdSSR);
+
 });


### PR DESCRIPTION
## Context

A mix-up of message IDs


## Changes proposed in this pull request

* Use the correct Message ID
* Add a comment to make the code clearer
* Add a test


## Guidance to review

Check this looks sensible


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
