### PR TITLE
bugfix/django-memory

### DIFF
--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -61,7 +61,7 @@ module "django-app" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   #source                    = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
   source                     = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v5.0.1-ecs"
-  memory                     = var.env == "prod" ? 2048 : 512
+  memory                     = var.env == "prod" ? 8192 : 512
   cpu                        = var.env == "prod" ? 4096 : 256
   create_listener            = true
   create_networking          = true


### PR DESCRIPTION
## Context

The minimum memory for a 4 cpu Fargate instance is 8gb

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html

```
No Fargate configuration exists for given values: 4096 CPU, 2048 memory. See the Amazon ECS documentation for the valid values
```

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
