### PR TITLE
Remove escape_curly_brackets

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -34,10 +34,6 @@ env = get_settings()
 tokeniser = get_tokeniser()
 
 
-def escape_curly_brackets(text: str) -> str:
-    return text.replace("{", "{{").replace("}", "}}")
-
-
 class UUIDPrimaryKeyBase(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
@@ -685,8 +681,8 @@ class ChatMessage(UUIDPrimaryKeyBase):
 
     def to_langchain(self) -> AnyMessage:
         if self.role == self.Role.ai:
-            return AIMessage(content=escape_curly_brackets(self.text))
-        return HumanMessage(content=escape_curly_brackets(self.text))
+            return AIMessage(content=self.text)
+        return HumanMessage(content=self.text)
 
     def log(self):
         n_selected_files = self.chat.file_set.count()


### PR DESCRIPTION
## Context

`escape_curly_brackets` sometimes causes `{{{{` to appear where only `{{` should. Though we're not certain it's no longer needed, testing has been successful, and this will help us find out!


## Changes proposed in this pull request

Remove `escape_curly_brackets`


## Guidance to review

Try to break it!


## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
