### PR TITLE
feature/only-display-banner-to-co

### DIFF
--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -76,7 +76,7 @@
         </chat-title>
 
         <chat-controller class="iai-chat-container" data-stream-url="{{ streaming.endpoint }}" data-models="{{ llm_options | to_json }}">
-          
+
           <ol aria-label="Redbox conversation" class="rb-chat-message__container js-message-container">
 
             {# SSR messages #}
@@ -107,9 +107,11 @@
       {% if not messages %}
 
         {# Notice area #}
+        {% current_chat.user.business_unit.department == 'Cabinet Office' %}
         <div class="rb-notice">
           <p>The Cabinet Office Digital Training Team needs your help to shape the Redbox training offered across the Cabinet Office. Please take a moment to complete <a class="govuk-link govuk-!-display-inline-block" href="https://docs.google.com/forms/d/e/1FAIpQLSdNkRUZbt2-qQiiI-4WuRbwiu7ruAkavaD0atQk0TxbsDIcJQ/viewform?usp=dialog" rel="noopener">this 5-minute survey</a> by 28th February.</p>
         </div>
+        {% endif %}
 
         {% set canned_prompts %}
             <canned-prompts class="chat-options"></canned-prompts>

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -107,7 +107,7 @@
       {% if not messages %}
 
         {# Notice area #}
-        {% current_chat.user.business_unit.department == 'Cabinet Office' %}
+        {% if current_chat.user.business_unit.department == 'Cabinet Office' %}
         <div class="rb-notice">
           <p>The Cabinet Office Digital Training Team needs your help to shape the Redbox training offered across the Cabinet Office. Please take a moment to complete <a class="govuk-link govuk-!-display-inline-block" href="https://docs.google.com/forms/d/e/1FAIpQLSdNkRUZbt2-qQiiI-4WuRbwiu7ruAkavaD0atQk0TxbsDIcJQ/viewform?usp=dialog" rel="noopener">this 5-minute survey</a> by 28th February.</p>
         </div>


### PR DESCRIPTION
## Context

As a DSIT user i do not want to see cabinet office specific messages

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

this is deployed to dev, login and observe that you can see the banner if you are a CO user, then go to the admin and change yourself to DSIT and observe that you cant

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
