### PR TITLE
feature/remove-sensitive-text

### DIFF
--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -172,14 +172,23 @@ class ChatMessageAdmin(ExportMixin, admin.ModelAdmin):
 class FileInline(admin.StackedInline):
     model = models.File
     ordering = ("modified_at",)
+    fields = (
+        "status",
+        "original_file",
+        "ingest_error",
+        "chat",
+        "token_count",
+        "task",
+    )  # do not include 'text' as it contravenes our DPIA
+    readonly_fields = ("status", "original_file", "ingest_error", "chat", "token_count", "task")
     extra = 0
 
 
 class ChatMessageInline(admin.StackedInline):
     model = models.ChatMessage
     ordering = ("created_at",)
-    fields = ["id", "created_at", "text", "role", "rating", "delay"]
-    readonly_fields = ["id", "created_at", "text", "role", "rating", "delay"]
+    fields = ["id", "created_at", "role", "rating", "delay"]  # do not include 'text' as it contravenes our DPIA
+    readonly_fields = ["id", "created_at", "role", "rating", "delay"]
     extra = 0
 
 
@@ -219,6 +228,16 @@ class FileAdmin(ExportMixin, admin.ModelAdmin):
     date_hierarchy = "created_at"
     actions = ["reupload"]
     search_fields = ["chat__user__email", "file_name"]
+
+    fields = (
+        "status",
+        "original_file",
+        "ingest_error",
+        "chat",
+        "token_count",
+        "task",
+    )  # do not include 'text' as it contravenes our DPIA
+    readonly_fields = ("status", "original_file", "ingest_error", "chat", "token_count", "task")
 
 
 admin.site.register(models.DepartmentBusinessUnit, DepartmentBusinessUnitAdmin)


### PR DESCRIPTION
## Context

As an Admin I no longer want to be able to see a users text so that I do not have to disclose this or sign any more documents 

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

check dev, no text should be visible to an admin:
![image](https://github.com/user-attachments/assets/28ac2cd1-3ffd-483d-ac2c-5167a3777af0)

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
