### PR TITLE
feature/simplify-redbox-core

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -23,7 +23,7 @@ logger.info("WEBSOCKET_SCHEME is: %s", settings.WEBSOCKET_SCHEME)
 
 
 class ChatConsumer(AsyncWebsocketConsumer):
-    redbox = Redbox(debug=settings.DEBUG)
+    redbox = Redbox()
 
     async def receive(self, text_data=None, _bytes_data=None):
         """Receive & respond to message from browser websocket."""

--- a/django_app/redbox_app/redbox_core/views/api_views.py
+++ b/django_app/redbox_app/redbox_core/views/api_views.py
@@ -86,7 +86,7 @@ class ChatMessageSerializer(Serializer):
 
 
 class ChatMessageView(APIView):
-    redbox = Redbox(debug=settings.DEBUG)
+    redbox = Redbox()
 
     def post(self, request, chat_id: UUID):
         serializer = ChatMessageSerializer(data=request.data)

--- a/django_app/redbox_app/redbox_core/views/api_views.py
+++ b/django_app/redbox_app/redbox_core/views/api_views.py
@@ -3,7 +3,6 @@ from http import HTTPStatus
 from typing import ClassVar
 from uuid import UUID
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
 from rest_framework import status

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -41,7 +41,7 @@ async def test_chat_consumer_with_new_session(chat: Chat, mocked_connect: Connec
     # Given
 
     # When
-    with patch("redbox_app.redbox_core.consumers.ChatConsumer.redbox._get_runnable", new=lambda _: mocked_connect):
+    with patch("redbox.models.RedboxState.get_llm", new=lambda _: mocked_connect):
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
         communicator.scope["user"] = chat.user
         communicator.scope["url_route"] = {"kwargs": {"chat_id": chat.id}}
@@ -76,7 +76,7 @@ async def test_chat_consumer_staff_user(staff_user: User, chat: Chat, mocked_con
     # Given
 
     # When
-    with patch("redbox_app.redbox_core.consumers.ChatConsumer.redbox._get_runnable", new=lambda _: mocked_connect):
+    with patch("redbox.models.RedboxState.get_llm", new=lambda _: mocked_connect):
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
         communicator.scope["user"] = staff_user
         communicator.scope["url_route"] = {"kwargs": {"chat_id": chat.id}}
@@ -108,7 +108,7 @@ async def test_chat_consumer_with_existing_session(chat: Chat, mocked_connect: C
     # Given
 
     # When
-    with patch("redbox_app.redbox_core.consumers.ChatConsumer.redbox._get_runnable", new=lambda _: mocked_connect):
+    with patch("redbox.models.RedboxState.get_llm", new=lambda _: mocked_connect):
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
         communicator.scope["user"] = chat.user
         communicator.scope["url_route"] = {"kwargs": {"chat_id": chat.id}}
@@ -130,7 +130,7 @@ async def test_chat_consumer_with_naughty_question(chat: Chat, mocked_connect: C
     # Given
 
     # When
-    with patch("redbox_app.redbox_core.consumers.ChatConsumer.redbox._get_runnable", new=lambda _: mocked_connect):
+    with patch("redbox.models.RedboxState.get_llm", new=lambda _: mocked_connect):
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
         communicator.scope["user"] = chat.user
         communicator.scope["url_route"] = {"kwargs": {"chat_id": chat.id}}
@@ -178,7 +178,7 @@ async def test_chat_consumer_with_selected_files(
 
     # When
     with patch(
-        "redbox_app.redbox_core.consumers.ChatConsumer.redbox._get_runnable",
+        "redbox.models.RedboxState.get_llm",
         new=lambda _: mocked_connect_with_several_files,
     ):
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
@@ -231,9 +231,7 @@ async def test_chat_consumer_with_connection_error(chat: Chat, mocked_breaking_c
     # Given
 
     # When
-    with patch(
-        "redbox_app.redbox_core.consumers.ChatConsumer.redbox._get_runnable", new=lambda _: mocked_breaking_connect
-    ):
+    with patch("redbox.models.RedboxState.get_llm", new=lambda _: mocked_breaking_connect):
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
         communicator.scope["user"] = chat.user
         communicator.scope["url_route"] = {"kwargs": {"chat_id": chat.id}}
@@ -259,7 +257,7 @@ async def test_chat_consumer_with_explicit_unhandled_error(
 
     # When
     with patch(
-        "redbox_app.redbox_core.consumers.ChatConsumer.redbox._get_runnable",
+        "redbox.models.RedboxState.get_llm",
         new=lambda _: mocked_connect_with_explicit_unhandled_error,
     ):
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
@@ -292,7 +290,7 @@ async def test_chat_consumer_with_rate_limited_error(chat: Chat, mocked_connect_
 
     # When
     with patch(
-        "redbox_app.redbox_core.consumers.ChatConsumer.redbox._get_runnable",
+        "redbox.models.RedboxState.get_llm",
         new=lambda _: mocked_connect_with_rate_limited_error,
     ):
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
@@ -326,7 +324,7 @@ async def test_chat_consumer_with_explicit_no_document_selected_error(
 
     # When
     with patch(
-        "redbox_app.redbox_core.consumers.ChatConsumer.redbox._get_runnable",
+        "redbox.models.RedboxState.get_llm",
         new=lambda _: mocked_connect_with_explicit_no_document_selected_error,
     ):
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
@@ -357,7 +355,7 @@ async def test_chat_consumer_redbox_state(
     # When
     with (
         patch(
-            "redbox_app.redbox_core.consumers.ChatConsumer.redbox._get_runnable",
+            "redbox.models.RedboxState.get_llm",
             new=lambda _: mocked_connect_with_several_files,
         ),
         patch("redbox_app.redbox_core.consumers.ChatConsumer.redbox.run") as mock_run,

--- a/django_app/tests/views/test_chat_message.py
+++ b/django_app/tests/views/test_chat_message.py
@@ -34,9 +34,7 @@ def test_post_pass(chat: Chat, mocked_connect, client):
     client.force_login(chat.user)
 
     # When
-    with patch(
-        "redbox_app.redbox_core.views.api_views.ChatMessageView.redbox._get_runnable", new=lambda _: mocked_connect
-    ):
+    with patch("redbox.models.RedboxState.get_llm", new=lambda _: mocked_connect):
         message = "write me poem"
         response = client.post(url, {"message": "write me poem"})
         assert response.status_code == 200

--- a/redbox-core/redbox/app.py
+++ b/redbox-core/redbox/app.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, BaseMessage
 
 from redbox.models.chain import RedboxState
 
@@ -13,7 +13,7 @@ logger = getLogger(__name__)
 
 
 class Redbox:
-    def run_sync(self, state: RedboxState):
+    def run_sync(self, state: RedboxState) -> BaseMessage:
         """
         Run Redbox without streaming events. This simpler, synchronous execution enables use of the graph debug logging
         """

--- a/redbox-core/redbox/app.py
+++ b/redbox-core/redbox/app.py
@@ -24,7 +24,7 @@ class Redbox:
         state: RedboxState,
         response_tokens_callback=_default_callback,
     ) -> AIMessage:
-        final_state = None
+        final_message = ""
         async for event in state.get_llm().astream_events(
             state.get_messages(),
             version="v2",
@@ -32,7 +32,6 @@ class Redbox:
             kind = event["event"]
             if kind == "on_chat_model_stream":
                 content = event["data"]["chunk"].content
+                final_message += content
                 await response_tokens_callback(content)
-            elif kind == "on_chain_end":
-                final_state = event["data"]["output"]
-        return final_state
+        return AIMessage(content=final_message)

--- a/redbox-core/redbox/app.py
+++ b/redbox-core/redbox/app.py
@@ -1,11 +1,8 @@
 from logging import getLogger
 
-from langchain.chat_models import init_chat_model
-from langchain_core.messages import BaseMessage
-from langchain_core.prompts import PromptTemplate
+from langchain_core.messages import AIMessage
 
 from redbox.models.chain import RedboxState
-from redbox.models.settings import get_settings
 
 
 async def _default_callback(*args, **kwargs):
@@ -16,47 +13,20 @@ logger = getLogger(__name__)
 
 
 class Redbox:
-    def __init__(self, debug: bool = False):
-        self.debug = debug
-
-    def _get_runnable(self, state: RedboxState):
-        if state.chat_backend.provider == "google_vertexai":
-            return init_chat_model(
-                model=state.chat_backend.name,
-                model_provider=state.chat_backend.provider,
-                location="europe-west1",
-                # europe-west1 = Belgium
-            )
-        return init_chat_model(
-            model=state.chat_backend.name,
-            model_provider=state.chat_backend.provider,
-        )
-
-    def get_messages(self, state: RedboxState) -> list[BaseMessage]:
-        settings = get_settings()
-
-        input_state = state.model_dump()
-        system_messages = (
-            PromptTemplate.from_template(settings.system_prompt_template, template_format="jinja2")
-            .invoke(input=input_state)
-            .to_messages()
-        )
-        return system_messages + state.messages
-
     def run_sync(self, state: RedboxState):
         """
         Run Redbox without streaming events. This simpler, synchronous execution enables use of the graph debug logging
         """
-        return self._get_runnable(state).invoke(input=self.get_messages(state))
+        return state.get_llm().invoke(input=state.get_messages())
 
     async def run(
         self,
         state: RedboxState,
         response_tokens_callback=_default_callback,
-    ) -> RedboxState:
+    ) -> AIMessage:
         final_state = None
-        async for event in self._get_runnable(state).astream_events(
-            self.get_messages(state),
+        async for event in state.get_llm().astream_events(
+            state.get_messages(),
             version="v2",
         ):
             kind = event["event"]

--- a/redbox-core/redbox/app.py
+++ b/redbox-core/redbox/app.py
@@ -1,7 +1,8 @@
 from logging import getLogger
 
 from langchain.chat_models import init_chat_model
-from langchain_core.prompts import ChatPromptTemplate, PromptTemplate
+from langchain_core.messages import BaseMessage
+from langchain_core.prompts import PromptTemplate
 
 from redbox.models.chain import RedboxState
 from redbox.models.settings import get_settings
@@ -19,36 +20,34 @@ class Redbox:
         self.debug = debug
 
     def _get_runnable(self, state: RedboxState):
-        settings = get_settings()
         if state.chat_backend.provider == "google_vertexai":
-            llm = init_chat_model(
+            return init_chat_model(
                 model=state.chat_backend.name,
                 model_provider=state.chat_backend.provider,
                 location="europe-west1",
                 # europe-west1 = Belgium
             )
-        else:
-            llm = init_chat_model(
-                model=state.chat_backend.name,
-                model_provider=state.chat_backend.provider,
-            )
+        return init_chat_model(
+            model=state.chat_backend.name,
+            model_provider=state.chat_backend.provider,
+        )
+
+    def get_messages(self, state: RedboxState) -> list[BaseMessage]:
+        settings = get_settings()
 
         input_state = state.model_dump()
-        messages = (
-            [settings.system_prompt_template]
-            + state.messages[:-1]
-            + PromptTemplate.from_template(settings.question_prompt_template, template_format="jinja2")
+        system_messages = (
+            PromptTemplate.from_template(settings.system_prompt_template, template_format="jinja2")
             .invoke(input=input_state)
             .to_messages()
         )
-        return ChatPromptTemplate.from_messages(messages=messages) | llm
+        return system_messages + state.messages
 
     def run_sync(self, state: RedboxState):
         """
         Run Redbox without streaming events. This simpler, synchronous execution enables use of the graph debug logging
         """
-        request_dict = state.model_dump()
-        return self._get_runnable(state).invoke(input=request_dict)
+        return self._get_runnable(state).invoke(input=self.get_messages(state))
 
     async def run(
         self,
@@ -56,10 +55,8 @@ class Redbox:
         response_tokens_callback=_default_callback,
     ) -> RedboxState:
         final_state = None
-        request_dict = state.model_dump()
-        logger.info("Request: %s", {k: request_dict[k] for k in request_dict.keys() - {"ai_settings"}})
         async for event in self._get_runnable(state).astream_events(
-            request_dict,
+            self.get_messages(state),
             version="v2",
         ):
             kind = event["event"]

--- a/redbox-core/redbox/models/__init__.py
+++ b/redbox-core/redbox/models/__init__.py
@@ -1,5 +1,7 @@
 from redbox.models.settings import Settings
+from redbox.models.chain import RedboxState
 
 __all__ = [
+    "RedboxState",
     "Settings",
 ]

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -1,11 +1,37 @@
+from langchain.chat_models import init_chat_model
 from langchain_core.documents import Document
-from langchain_core.messages import AnyMessage
+from langchain_core.messages import AnyMessage, BaseMessage
+from langchain_core.prompts import PromptTemplate
 from pydantic import BaseModel, Field
 
-from redbox.models.settings import ChatLLMBackend
+from redbox.models.settings import ChatLLMBackend, get_settings
 
 
 class RedboxState(BaseModel):
     documents: list[Document] = Field(description="List of files to process", default_factory=list)
     messages: list[AnyMessage] = Field(description="All previous messages in chat", default_factory=list)
     chat_backend: ChatLLMBackend = Field(description="User request AI settings", default_factory=ChatLLMBackend)
+
+    def get_llm(self):
+        if self.chat_backend.provider == "google_vertexai":
+            return init_chat_model(
+                model=self.chat_backend.name,
+                model_provider=self.chat_backend.provider,
+                location="europe-west1",
+                # europe-west1 = Belgium
+            )
+        return init_chat_model(
+            model=self.chat_backend.name,
+            model_provider=self.chat_backend.provider,
+        )
+
+    def get_messages(self) -> list[BaseMessage]:
+        settings = get_settings()
+
+        input_state = self.model_dump()
+        system_messages = (
+            PromptTemplate.from_template(settings.system_prompt_template, template_format="jinja2")
+            .invoke(input=input_state)
+            .to_messages()
+        )
+        return system_messages + self.messages

--- a/redbox-core/redbox/models/settings.py
+++ b/redbox-core/redbox/models/settings.py
@@ -75,19 +75,15 @@ class Settings(BaseSettings):
 You follow instructions and respond to queries accurately and concisely, and are professional in all your
 interactions with users. You use British English spellings and phrases rather than American English.
 
-If you are provided with documents you use those as primary sources for information and use them to respond to the users queries
-"""
-
-    question_prompt_template: str = """
 {% if documents is defined and documents|length > 0 %}
-Documents:
+Use the following documents as primary sources for information and use them to respond to the users queries
+
 {% for d in documents %}
 Title: {{d.metadata.get("uri", "unknown document")}}
 {{d.page_content}}
 
 {% endfor %}
 {% endif %}
-Question: {{messages[-1].content}}
 """
 
     model_config = SettingsConfigDict(env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True)

--- a/utilities/draw_graph.py
+++ b/utilities/draw_graph.py
@@ -1,8 +1,0 @@
-from langchain_core.runnables import RunnablePassthrough
-
-from redbox.app import Redbox
-
-app = Redbox(retriever=RunnablePassthrough())
-
-for g in ["root", "chat/documents"]:
-    app.draw(graph_to_draw=g, output_path=f"../docs/architecture/graph/{g.replace('/', '_')}.png")


### PR DESCRIPTION
## Context

As an Engineer I want to simplify our code such that it is possible to make systematic changes in the future

## Changes proposed in this pull request

The key commit is https://github.com/i-dot-ai/redbox/pull/1427/commits/ca5b9233b28c5932d9f49ab1c54833247683c201 everything else is formatting and refactoring

We used to have two system prompts: `system_prompt_template` for general system behaviour and `question_prompt_template` which was a mixture of documents and the users question. The changes are:

1. we now have just one system prompt `system_prompt_template` which is general behaviour and documents. The users last question is now just the last item in the chat history

2. the function called `get_runnable` that created a langchain runnable our of our system prompts, chat history, this has now only initiates the llm with the system prompt and any documents and the messages are subsequently passes in as a argument when we call the LLM.


out of scope: there is a still a lot we could do to simplify this code like:
* the `Redbox` class is static, this could just be merged into `RedboxState`
* `redbox.chains.componts` could be moved into django `Settings` or even just removed when we have litellm
* `redbox.models` could be squashed into a single file

I have not done this to keep code diff focussed

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
