### PR TITLE
Show error message if >=15 seconds to first response

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/message-input.js
+++ b/django_app/frontend/src/js/web-components/chats/message-input.js
@@ -4,6 +4,7 @@ export class MessageInput extends HTMLElement {
   constructor() {
     super();
     this.textarea = this.querySelector("textarea");
+    this.previousPrompt = "";
   }
 
   connectedCallback() {
@@ -50,7 +51,19 @@ export class MessageInput extends HTMLElement {
     if (!this.textarea) {
       return;
     }
+    this.previousPrompt = this.textarea.value;
     this.textarea.value = "";
+    this.#adjustHeight();
+  };
+
+  /**
+   * Shows the previous user prompt, if something has gone wrong
+   */
+  undoReset = () => {
+    if (!this.textarea) {
+      return;
+    }
+    this.textarea.value = this.previousPrompt;
     this.#adjustHeight();
   };
 }


### PR DESCRIPTION
## Context

We're getting longer response times than anticipated in some situations.


## Changes proposed in this pull request

* Show an error message if it takes longer than 15 seconds to get a response from the server (through the websocket)
* Send an event to Plausible, along with the selected LLM


## Guidance to review

You could add a timeout to `consumers.py` to test if you wanted to. Or just check the code looks sensible.


## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-1044


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
