### PR TITLE
feature/potentially more than one worker

### DIFF
--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -382,7 +382,6 @@ Q_CLUSTER = {
     "max_attempts": env.int("Q_MAX_ATTEMPTS", 1),
     "catch_up": False,
     "orm": "default",
-    "workers": 1,
 }
 
 GOOGLE_ANALYTICS_TAG = env.str("GOOGLE_ANALYTICS_TAG", " ")


### PR DESCRIPTION
## Context

as a user I want to allow the number of workers to be greater than 1 so that my documents get processed faster

## Changes proposed in this pull request

we have been setting the number of workers to 1, by removing this setting the code will use as many workers as there are CPUs https://django-q2.readthedocs.io/en/master/configure.html#workers

as this task is single threaded and lightweight this should be fine

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
