### PR TITLE
feature/data-dumps-loads-from-s3

### DIFF
--- a/django_app/redbox_app/redbox_core/management/commands/dumpdata_s3.py
+++ b/django_app/redbox_app/redbox_core/management/commands/dumpdata_s3.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import boto3
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Exports data and uploads it to S3"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--filename", type=str, default="data.json")
+
+    def handle(self, *_args, **kwargs):
+        call_command("dumpdata", "redbox_core", stdout=Path.open(Path(kwargs["filename"]), "w"))
+
+        # Upload to S3
+        s3 = boto3.client("s3")
+        bucket_name = settings.AWS_STORAGE_BUCKET_NAME
+
+        try:
+            s3.upload_file(kwargs["filename"], bucket_name, kwargs["filename"])
+            self.stdout.write(self.style.SUCCESS("Successfully uploaded data to S3"))
+        except Exception as e:  # noqa: BLE001
+            self.stdout.write(self.style.ERROR(f"Failed to upload to S3: {e}"))

--- a/django_app/redbox_app/redbox_core/management/commands/loaddata_s3.py
+++ b/django_app/redbox_app/redbox_core/management/commands/loaddata_s3.py
@@ -1,0 +1,22 @@
+import boto3
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Loads data from S3 into the database"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--filename", type=str, default="data.json")
+
+    def handle(self, *_args, **kwargs):
+        bucket_name = settings.AWS_STORAGE_BUCKET_NAME
+
+        s3 = boto3.client("s3")
+        s3.download_file(bucket_name, kwargs["filename"], kwargs["filename"])
+
+        try:
+            call_command("loaddata", kwargs["filename"])
+        except Exception as e:  # noqa: BLE001
+            self.stdout.write(self.style.ERROR(f"Failed to load data into the database: {e}"))


### PR DESCRIPTION
## Context

As an Engineer I want to be able to dump our data to s3 and reload it so that we can rebuild a database from scratch when we need to:
* squash migrations
* have breaking TF changes

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
