### PR TITLE
Add comma-separator to token limits

### DIFF
--- a/django_app/frontend/src/css/chats/chats.scss
+++ b/django_app/frontend/src/css/chats/chats.scss
@@ -271,6 +271,7 @@ message-input:has(textarea:placeholder-shown) label {
   color: var(--iai-colour-secondary-teal);
   cursor: pointer;
   display: inline-block;
+  margin-top: 1rem;
   padding: 0.25rem 0.75rem;
 }
 .iai-chat-bubble__text details ul {

--- a/django_app/frontend/src/js/web-components/chats/chat-controller.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-controller.js
@@ -53,7 +53,7 @@ class ChatController extends HTMLElement {
           <details>
             <summary>Model token limits</summary>
             <ul class="rb-token-sizes">
-              ${models.map((model) => `<li><span>${model.name}: </span><span>${model.max_tokens} tokens</li>`).join("")}
+              ${models.map((model) => `<li><span>${model.name}: </span><span>${model.max_tokens.toLocaleString('en-GB')} tokens</li>`).join("")}
             </ul>
           </details>
         `);


### PR DESCRIPTION
## Context

User-feedback has shown the the token-limits are hard to read due to lack of comma separator


## Changes proposed in this pull request

Add comma separators to these numbers:
<img src="https://github.com/user-attachments/assets/c202cf6a-1221-4e0b-a774-d4214e194e7e" width="200"/>



## Guidance to review

Add big docs to force the message to appear and then check the numbers


## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
