### PR TITLE
Lock to a specific version of gov.uk design system

### DIFF
--- a/django_app/frontend/package.json
+++ b/django_app/frontend/package.json
@@ -47,7 +47,7 @@
   },
   "author": "",
   "dependencies": {
-    "govuk-frontend": "^5.2.0",
+    "govuk-frontend": "5.10.2",
     "i.ai-design-system": "^0.5.2",
     "lit": "^3.2.1",
     "mermaid": "^11.2.1",


### PR DESCRIPTION
## Context

The CSS build is failing in the github action. This appears to be due to a govuk design system update.


## Changes proposed in this pull request

Lock to version 5.10.2 of the govuk design system.


## Guidance to review

Check it builds and looks okay!

